### PR TITLE
initializes the TrustManagerFactory to prevent IllegalStateException

### DIFF
--- a/libonionkit/src/info/guardianproject/onionkit/trust/StrongHttpsClient.java
+++ b/libonionkit/src/info/guardianproject/onionkit/trust/StrongHttpsClient.java
@@ -1,31 +1,28 @@
 
 package info.guardianproject.onionkit.trust;
 
+import android.content.Context;
+import android.util.Log;
+import ch.boye.httpclientandroidlib.HttpHost;
+import ch.boye.httpclientandroidlib.conn.ClientConnectionOperator;
+import ch.boye.httpclientandroidlib.conn.scheme.PlainSocketFactory;
+import ch.boye.httpclientandroidlib.conn.scheme.Scheme;
+import ch.boye.httpclientandroidlib.conn.scheme.SchemeRegistry;
+import ch.boye.httpclientandroidlib.impl.client.DefaultHttpClient;
+import ch.boye.httpclientandroidlib.impl.conn.tsccm.ThreadSafeClientConnManager;
 import info.guardianproject.onionkit.R;
 import info.guardianproject.onionkit.proxy.MyThreadSafeClientConnManager;
 import info.guardianproject.onionkit.proxy.SocksProxyClientConnOperator;
 
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509TrustManager;
 import java.io.IOException;
 import java.io.InputStream;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
-
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.TrustManagerFactory;
-import javax.net.ssl.X509TrustManager;
-
-import android.content.Context;
-import android.util.Log;
-import ch.boye.httpclientandroidlib.HttpHost;
-import ch.boye.httpclientandroidlib.conn.ClientConnectionOperator;
-import ch.boye.httpclientandroidlib.conn.params.ConnRoutePNames;
-import ch.boye.httpclientandroidlib.conn.scheme.PlainSocketFactory;
-import ch.boye.httpclientandroidlib.conn.scheme.Scheme;
-import ch.boye.httpclientandroidlib.conn.scheme.SchemeRegistry;
-import ch.boye.httpclientandroidlib.impl.client.DefaultHttpClient;
-import ch.boye.httpclientandroidlib.impl.conn.tsccm.ThreadSafeClientConnManager;
 
 public class StrongHttpsClient extends DefaultHttpClient {
 
@@ -50,14 +47,16 @@ public class StrongHttpsClient extends DefaultHttpClient {
         
         try {
 //            mTrustManager = new StrongTrustManager(context);
-        	TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+            KeyStore keyStore = loadKeyStore();
+            TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+            trustManagerFactory.init(keyStore);
         	for (TrustManager trustManager : trustManagerFactory.getTrustManagers()) {          	  
         	    if (trustManager instanceof X509TrustManager) {  
         	    	mTrustManager = trustManagerFactory.getTrustManagers()[0];  
         	    }  
         	}  
         	
-            sFactory = new StrongSSLSocketFactory(context, mTrustManager, loadKeyStore(), TRUSTSTORE_PASSWORD);
+            sFactory = new StrongSSLSocketFactory(context, mTrustManager, keyStore, TRUSTSTORE_PASSWORD);
             mRegistry.register(new Scheme("https", 443, sFactory));
         } catch (Exception e) {
             throw new AssertionError(e);


### PR DESCRIPTION
Initializes the TrustManagerFactory to prevent "IllegalStateException: TrustManagerFactory is not initialized", caused by the call "trustManagerFactory.getTrustManagers()".

PS: nevermind the imports, they're just rearranged.
