### PR TITLE
fixed orbot proxy reset for kitkat

### DIFF
--- a/libnetcipher/src/info/guardianproject/onionkit/web/WebkitProxy.java
+++ b/libnetcipher/src/info/guardianproject/onionkit/web/WebkitProxy.java
@@ -40,7 +40,7 @@ public class WebkitProxy {
     public static boolean setProxy(String appClass, Context ctx, String host, int port) throws Exception
     {
       
-    	setSystemProperties(host, port);
+    	//setSystemProperties(host, port);
 
         boolean worked = false;
 


### PR DESCRIPTION
Hey @n8fr8 , this seems to fix the reset problem. 
Reasoning: What I noticed is that for the KitKat portion in WebKitProxy, these setProperty(...) calls were done twice. Removing this line seems to fix KitKat, and also doesn't seem to cause problems on previous versions. 
Tested with Kitkat, 4.1.2 en 2.3.3.

Let me know if you can test/reproduce this, I can provide you with a new ddg.apk as well if that would help.

Koen
