### PR TITLE
Add Gradle build file

### DIFF
--- a/libnetcipher/build.gradle
+++ b/libnetcipher/build.gradle
@@ -1,0 +1,43 @@
+buildscript {
+	repositories {
+		mavenCentral()
+	}
+
+	dependencies {
+		classpath 'com.android.tools.build:gradle:1.0.0'
+	}
+}
+
+apply plugin: 'com.android.library'
+
+repositories {
+	mavenCentral()
+}
+dependencies {
+	// If you want to fetch these from Maven, uncomment these lines and change
+	// the *.jar depend to exclude these libs:
+	// compile 'com.android.support:support-v4:21.0.3'
+	// compile 'com.madgag.spongycastle:core:1.51.0.0'
+	compile fileTree(dir: 'libs', include: '*.jar')
+}
+
+android {
+	compileSdkVersion 21
+		buildToolsVersion '21.1.2'
+
+		sourceSets {
+			main {
+				manifest.srcFile 'AndroidManifest.xml'
+					java.srcDirs = ['src']
+					resources.srcDirs = ['src']
+					aidl.srcDirs = ['src']
+					renderscript.srcDirs = ['src']
+					res.srcDirs = ['res']
+					assets.srcDirs = ['assets']
+			}
+		}
+
+	lintOptions {
+		abortOnError false
+	}
+}


### PR DESCRIPTION
One pull request adding Gradle support was closed recently, and the other is out of date and removes support for Ant/Eclipse.

This PR adds a single `build.gradle` file which uses the existing Ant/Eclipse compatible directory structure. It does not modernize the build, instead, it just allows modern tools (Gradle/Android Studio) to use the existing project structure.

@n8fr8 RE our discussion on the old Conversations Tor PR, This is (more or less) what I'm using for building `NetCipher` for Conversations. I thought it might be useful upstream as well.