### PR TITLE
Add Gradle/Android Studio generated files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,10 @@ gen/
 
 # Local configuration file (sdk path, etc)
 local.properties
+
+# Gradle
+build
+.gradle
+
+# IntelliJ / Android Studio
+*iml


### PR DESCRIPTION
Hey,

After building your library with Gradle and/or importing it to the Android Studio there are some leftover, IDE/gradle-generated files in my git-diff.

Please consider adding such lines to your .gitignore configurations.

Thanks!