### PR TITLE
Fix problem in gradle build file

### DIFF
--- a/libnetcipher/build.gradle
+++ b/libnetcipher/build.gradle
@@ -16,9 +16,9 @@ repositories {
 dependencies {
 	// If you want to fetch these from Maven, uncomment these lines and change
 	// the *.jar depend to exclude these libs:
-	// compile 'com.android.support:support-v4:21.0.3'
-	// compile 'com.madgag.spongycastle:core:1.51.0.0'
-	compile fileTree(dir: 'libs', include: '*.jar')
+	compile 'com.android.support:support-v4:22.1.1'
+	compile 'com.madgag.spongycastle:core:1.51.0.0'
+	compile files('libs/httpclientandroidlib-1.2.1.jar')
 }
 
 android {


### PR DESCRIPTION
When an app wants to use the latest support-v4 library and the libnetcipher library, they have a problem when using gradle. When trying to build, gradle runs into a conflict where the libnetcipher library is supplying its own support-v4 jar. This problem could be overridden using the "exclude module" gradle command (see https://stackoverflow.com/questions/20989317/multiple-dex-files-define-landroid-support-v4-accessibilityservice-accessibility) but it currently does not work since libnetcipher is explicitly including a jar and that cannot be overridden.

By changing to use the maven dependency instead of the explicit jar, the mismatched jar problem can be worked around.