### PR TITLE
NetCipher methods for working with HttpURLConnection

### DIFF
--- a/libnetcipher/src/info/guardianproject/netcipher/NetCipher.java
+++ b/libnetcipher/src/info/guardianproject/netcipher/NetCipher.java
@@ -59,19 +59,16 @@ public class NetCipher {
         }
     }
 
-    public static HttpsURLConnection getHttpsURLConnection(String urlString)
-            throws MalformedURLException, IOException, KeyManagementException {
+    public static HttpsURLConnection getHttpsURLConnection(String urlString) throws IOException {
         urlString.replaceFirst("^[Hh][Tt][Tt][Pp]:", "https:");
         return getHttpsURLConnection(new URL(urlString), false);
     }
 
-    public static HttpsURLConnection getHttpsURLConnection(Uri uri)
-            throws MalformedURLException, IOException, KeyManagementException {
+    public static HttpsURLConnection getHttpsURLConnection(Uri uri) throws IOException {
         return getHttpsURLConnection(uri.toString());
     }
 
-    public static HttpsURLConnection getHttpsURLConnection(URI uri)
-            throws MalformedURLException, IOException, KeyManagementException {
+    public static HttpsURLConnection getHttpsURLConnection(URI uri) throws IOException {
         if (TextUtils.equals(uri.getScheme(), "https"))
             return getHttpsURLConnection(uri.toURL(), false);
         else
@@ -79,8 +76,7 @@ public class NetCipher {
             return getHttpsURLConnection(uri.toString());
     }
 
-    public static HttpsURLConnection getHttpsURLConnection(URL url)
-            throws IOException, KeyManagementException {
+    public static HttpsURLConnection getHttpsURLConnection(URL url) throws IOException {
         return getHttpsURLConnection(url, false);
     }
 
@@ -107,18 +103,19 @@ public class NetCipher {
      * @param compatible
      * @return
      * @throws IOException
-     * @throws KeyManagementException
+     * @throws IllegalArgumentException if the proxy or TLS setup is incorrect
      */
     public static HttpsURLConnection getHttpsURLConnection(URL url, boolean compatible)
-            throws IOException, KeyManagementException {
+            throws IOException {
         SSLContext sslcontext;
         try {
             sslcontext = SSLContext.getInstance("TLSv1");
+            sslcontext.init(null, null, null); // null means use default
         } catch (NoSuchAlgorithmException e) {
-            e.printStackTrace();
-            return null;
+            throw new IllegalArgumentException(e);
+        } catch (KeyManagementException e) {
+            throw new IllegalArgumentException(e);
         }
-        sslcontext.init(null, null, null); // null means use default
         SSLSocketFactory tlsOnly = new TlsOnlySocketFactory(sslcontext.getSocketFactory(),
                 compatible);
         HttpsURLConnection.setDefaultSSLSocketFactory(tlsOnly);

--- a/libnetcipher/src/info/guardianproject/netcipher/NetCipher.java
+++ b/libnetcipher/src/info/guardianproject/netcipher/NetCipher.java
@@ -1,0 +1,101 @@
+
+package info.guardianproject.netcipher;
+
+import android.net.Uri;
+import android.text.TextUtils;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.InetSocketAddress;
+import java.net.MalformedURLException;
+import java.net.Proxy;
+import java.net.URI;
+import java.net.URL;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocketFactory;
+
+public class NetCipher {
+
+    private NetCipher() {
+        // this is a utility class with only static methods
+    }
+
+    public final static Proxy ORBOT_HTTP_PROXY = new Proxy(Proxy.Type.HTTP,
+            new InetSocketAddress("127.0.0.1", 8118));
+
+    private static Proxy proxy;
+
+    public static void setProxy(String host, int port) {
+        if (host != null && port > 0) {
+            InetSocketAddress isa = new InetSocketAddress(host, port);
+            proxy = new Proxy(Proxy.Type.HTTP, isa);
+        } else {
+            proxy = null;
+        }
+    }
+
+    public static void setProxy(Proxy proxy) {
+        NetCipher.proxy = proxy;
+    }
+
+    public static Proxy getProxy() {
+        return proxy;
+    }
+
+    public static HttpURLConnection getHttpURLConnection(String urlString)
+            throws MalformedURLException, IOException {
+        return getHttpURLConnection(new URL(urlString));
+    }
+
+    public static HttpURLConnection getHttpURLConnection(URL url) throws IOException {
+        if (proxy != null) {
+            return (HttpURLConnection) url.openConnection(proxy);
+        } else {
+            return (HttpURLConnection) url.openConnection();
+        }
+    }
+
+    public static HttpsURLConnection getHttpsURLConnection(String urlString)
+            throws MalformedURLException, IOException, KeyManagementException {
+        urlString.replaceFirst("^[Hh][Tt][Tt][Pp]:", "https:");
+        return getHttpsURLConnection(new URL(urlString));
+    }
+
+    public static HttpsURLConnection getHttpsURLConnection(Uri uri)
+            throws MalformedURLException, IOException, KeyManagementException {
+        return getHttpsURLConnection(uri.toString());
+    }
+
+    public static HttpsURLConnection getHttpsURLConnection(URI uri)
+            throws MalformedURLException, IOException, KeyManagementException {
+        if (TextUtils.equals(uri.getScheme(), "https"))
+            return getHttpsURLConnection(uri.toURL());
+        else
+            // otherwise force scheme to https
+            return getHttpsURLConnection(uri.toString());
+    }
+
+    public static HttpsURLConnection getHttpsURLConnection(URL url) throws IOException,
+            KeyManagementException {
+        SSLContext sslcontext;
+        try {
+            sslcontext = SSLContext.getInstance("TLSv1");
+        } catch (NoSuchAlgorithmException e) {
+            e.printStackTrace();
+            return null;
+        }
+        sslcontext.init(null, null, null); // null means use default
+        SSLSocketFactory NoSSLv3Factory = new TlsOnlySocketFactory(sslcontext.getSocketFactory());
+
+        HttpsURLConnection.setDefaultSSLSocketFactory(NoSSLv3Factory);
+        if (proxy != null) {
+            return (HttpsURLConnection) url.openConnection(proxy);
+        } else {
+            return (HttpsURLConnection) url.openConnection();
+        }
+    }
+}

--- a/libnetcipher/src/info/guardianproject/netcipher/NetCipher.java
+++ b/libnetcipher/src/info/guardianproject/netcipher/NetCipher.java
@@ -7,7 +7,6 @@ import android.text.TextUtils;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.InetSocketAddress;
-import java.net.MalformedURLException;
 import java.net.Proxy;
 import java.net.URI;
 import java.net.URL;
@@ -46,8 +45,7 @@ public class NetCipher {
         return proxy;
     }
 
-    public static HttpURLConnection getHttpURLConnection(String urlString)
-            throws MalformedURLException, IOException {
+    public static HttpURLConnection getHttpURLConnection(String urlString) throws IOException {
         return getHttpURLConnection(new URL(urlString));
     }
 
@@ -88,10 +86,9 @@ public class NetCipher {
      * @param compatible
      * @return
      * @throws IOException
-     * @throws KeyManagementException
+     * @throws IllegalArgumentException if the proxy or TLS setup is incorrect
      */
-    public static HttpsURLConnection getCompatibleHttpsURLConnection(URL url)
-            throws IOException, KeyManagementException {
+    public static HttpsURLConnection getCompatibleHttpsURLConnection(URL url) throws IOException {
         return getHttpsURLConnection(url, true);
     }
 

--- a/libnetcipher/src/info/guardianproject/netcipher/NetCipher.java
+++ b/libnetcipher/src/info/guardianproject/netcipher/NetCipher.java
@@ -45,27 +45,42 @@ public class NetCipher {
         return proxy;
     }
 
-    public static HttpURLConnection getHttpURLConnection(String urlString) throws IOException {
-        return getHttpURLConnection(new URL(urlString));
-    }
-
-    public static HttpURLConnection getHttpURLConnection(URL url) throws IOException {
-        if (proxy != null) {
-            return (HttpURLConnection) url.openConnection(proxy);
-        } else {
-            return (HttpURLConnection) url.openConnection();
-        }
-    }
-
+    /**
+     * Get a {@link HttpsURLConnection} from a URL {@link String} using the best
+     * TLS configuration available on the device.
+     *
+     * @param urlString
+     * @return the URL in an instance of {@link HttpsURLConnection}
+     * @throws IOException
+     * @throws IllegalArgumentException if the proxy or TLS setup is incorrect
+     */
     public static HttpsURLConnection getHttpsURLConnection(String urlString) throws IOException {
         urlString.replaceFirst("^[Hh][Tt][Tt][Pp]:", "https:");
         return getHttpsURLConnection(new URL(urlString), false);
     }
 
+    /**
+     * Get a {@link HttpsURLConnection} from a {@link Uri} using the best TLS
+     * configuration available on the device.
+     *
+     * @param uri
+     * @return the {@code uri} in an instance of {@link HttpsURLConnection}
+     * @throws IOException
+     * @throws IllegalArgumentException if the proxy or TLS setup is incorrect
+     */
     public static HttpsURLConnection getHttpsURLConnection(Uri uri) throws IOException {
         return getHttpsURLConnection(uri.toString());
     }
 
+    /**
+     * Get a {@link HttpsURLConnection} from a {@link URI} using the best TLS
+     * configuration available on the device.
+     *
+     * @param uri
+     * @return the {@code uri} in an instance of {@link HttpsURLConnection}
+     * @throws IOException
+     * @throws IllegalArgumentException if the proxy or TLS setup is incorrect
+     */
     public static HttpsURLConnection getHttpsURLConnection(URI uri) throws IOException {
         if (TextUtils.equals(uri.getScheme(), "https"))
             return getHttpsURLConnection(uri.toURL(), false);
@@ -74,6 +89,15 @@ public class NetCipher {
             return getHttpsURLConnection(uri.toString());
     }
 
+    /**
+     * Get a {@link HttpsURLConnection} from a {@link URL} using the best TLS
+     * configuration available on the device.
+     *
+     * @param url
+     * @return the {@code url} in an instance of {@link HttpsURLConnection}
+     * @throws IOException
+     * @throws IllegalArgumentException if the proxy or TLS setup is incorrect
+     */
     public static HttpsURLConnection getHttpsURLConnection(URL url) throws IOException {
         return getHttpsURLConnection(url, false);
     }
@@ -104,6 +128,96 @@ public class NetCipher {
      */
     public static HttpsURLConnection getHttpsURLConnection(URL url, boolean compatible)
             throws IOException {
+        HttpURLConnection connection = getHttpsURLConnection(url, compatible);
+        if (connection instanceof HttpsURLConnection) {
+            return (HttpsURLConnection) connection;
+        } else {
+            throw new IllegalArgumentException("not an HTTPS connection!");
+        }
+    }
+
+    /**
+     * Get a {@link HttpURLConnection} from a {@link URL}. If the connection is
+     * {@code https://}, it will use a more compatible, but less strong, TLS
+     * configuration.
+     *
+     * @param url
+     * @return the {@code url} in an instance of {@link HttpsURLConnection}
+     * @throws IOException
+     * @throws IllegalArgumentException if the proxy or TLS setup is incorrect
+     */
+    public static HttpURLConnection getCompatibleHttpURLConnection(URL url) throws IOException {
+        return getHttpURLConnection(url, true);
+    }
+
+    /**
+     * Get a {@link HttpURLConnection} from a URL {@link String}. If it is an
+     * {@code https://} link, then this will use the best TLS configuration
+     * available on the device.
+     *
+     * @param urlString
+     * @return the URL in an instance of {@link HttpURLConnection}
+     * @throws IOException
+     * @throws IllegalArgumentException if the proxy or TLS setup is incorrect
+     */
+    public static HttpURLConnection getHttpURLConnection(String urlString) throws IOException {
+        return getHttpURLConnection(new URL(urlString));
+    }
+
+    /**
+     * Get a {@link HttpURLConnection} from a {@link Uri}. If it is an
+     * {@code https://} link, then this will use the best TLS configuration
+     * available on the device.
+     *
+     * @param uri
+     * @return the {@code uri} in an instance of {@link HttpURLConnection}
+     * @throws IOException
+     * @throws IllegalArgumentException if the proxy or TLS setup is incorrect
+     */
+    public static HttpURLConnection getHttpURLConnection(Uri uri) throws IOException {
+        return getHttpURLConnection(uri.toString());
+    }
+
+    /**
+     * Get a {@link HttpURLConnection} from a {@link URI}. If it is an
+     * {@code https://} link, then this will use the best TLS configuration
+     * available on the device.
+     *
+     * @param uri
+     * @return the {@code uri} in an instance of {@link HttpURLConnection}
+     * @throws IOException
+     * @throws IllegalArgumentException if the proxy or TLS setup is incorrect
+     */
+    public static HttpURLConnection getHttpURLConnection(URI uri) throws IOException {
+        return getHttpURLConnection(uri.toURL());
+    }
+
+    /**
+     * Get a {@link HttpURLConnection} from a {@link URL}. If it is an
+     * {@code https://} link, then this will use the best TLS configuration
+     * available on the device.
+     *
+     * @param url
+     * @return the {@code url} in an instance of {@link HttpURLConnection}
+     * @throws IOException
+     * @throws IllegalArgumentException if the proxy or TLS setup is incorrect
+     */
+    public static HttpURLConnection getHttpURLConnection(URL url) throws IOException {
+        return (HttpURLConnection) getHttpURLConnection(url, false);
+    }
+
+    /**
+     * Get a {@link HttpURLConnection} from a {@link URL}, and specify whether
+     * it should use a more compatible, but less strong, suite of ciphers.
+     *
+     * @param url
+     * @param compatible
+     * @return the {@code url} in an instance of {@link HttpURLConnection}
+     * @throws IOException
+     * @throws IllegalArgumentException if the proxy or TLS setup is incorrect
+     */
+    public static HttpURLConnection getHttpURLConnection(URL url, boolean compatible)
+            throws IOException {
         SSLContext sslcontext;
         try {
             sslcontext = SSLContext.getInstance("TLSv1");
@@ -117,9 +231,9 @@ public class NetCipher {
                 compatible);
         HttpsURLConnection.setDefaultSSLSocketFactory(tlsOnly);
         if (proxy != null) {
-            return (HttpsURLConnection) url.openConnection(proxy);
+            return (HttpURLConnection) url.openConnection(proxy);
         } else {
-            return (HttpsURLConnection) url.openConnection();
+            return (HttpURLConnection) url.openConnection();
         }
     }
 }

--- a/libnetcipher/src/info/guardianproject/netcipher/TlsOnlySocketFactory.java
+++ b/libnetcipher/src/info/guardianproject/netcipher/TlsOnlySocketFactory.java
@@ -1,0 +1,438 @@
+/*
+ * Copyright 2015 Bhavit Singh Sengar
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * From https://stackoverflow.com/a/29946540
+ */
+
+package info.guardianproject.netcipher;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.net.SocketAddress;
+import java.net.SocketException;
+import java.nio.channels.SocketChannel;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.net.ssl.HandshakeCompletedListener;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+
+/**
+ * While making a secure connection, Android's {@link HttpsURLConnection} falls
+ * back to SSLv3 from TLSv1. This is a bug in android versions < 4.4. It can be
+ * fixed by removing the SSLv3 protocol from Enabled Protocols list. Use this as
+ * the {@link SSLSocketFactory} for
+ * {@link HttpsURLConnection#setDefaultSSLSocketFactory(SSLSocketFactory)}
+ *
+ * @author Bhavit S. Sengar
+ */
+public class TlsOnlySocketFactory extends SSLSocketFactory {
+    private final SSLSocketFactory delegate;
+
+    public TlsOnlySocketFactory() {
+        this.delegate = HttpsURLConnection.getDefaultSSLSocketFactory();
+    }
+
+    public TlsOnlySocketFactory(SSLSocketFactory delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public String[] getDefaultCipherSuites() {
+        return delegate.getDefaultCipherSuites();
+    }
+
+    @Override
+    public String[] getSupportedCipherSuites() {
+        return delegate.getSupportedCipherSuites();
+    }
+
+    private Socket makeSocketSafe(Socket socket) {
+        if (socket instanceof SSLSocket) {
+            socket = new TlsOnlySSLSocket((SSLSocket) socket);
+        }
+        return socket;
+    }
+
+    @Override
+    public Socket createSocket(Socket s, String host, int port, boolean autoClose)
+            throws IOException {
+        return makeSocketSafe(delegate.createSocket(s, host, port, autoClose));
+    }
+
+    @Override
+    public Socket createSocket(String host, int port) throws IOException {
+        return makeSocketSafe(delegate.createSocket(host, port));
+    }
+
+    @Override
+    public Socket createSocket(String host, int port, InetAddress localHost, int localPort)
+            throws IOException {
+        return makeSocketSafe(delegate.createSocket(host, port, localHost, localPort));
+    }
+
+    @Override
+    public Socket createSocket(InetAddress host, int port) throws IOException {
+        return makeSocketSafe(delegate.createSocket(host, port));
+    }
+
+    @Override
+    public Socket createSocket(InetAddress address, int port, InetAddress localAddress,
+            int localPort) throws IOException {
+        return makeSocketSafe(delegate.createSocket(address, port, localAddress, localPort));
+    }
+
+    private class TlsOnlySSLSocket extends DelegateSSLSocket {
+
+        private TlsOnlySSLSocket(SSLSocket delegate) {
+            super(delegate);
+
+        }
+
+        @Override
+        public void setEnabledProtocols(String[] protocols) {
+            if (protocols != null && protocols.length == 1 && "SSLv3".equals(protocols[0])) {
+
+                List<String> enabledProtocols = new ArrayList<String>(Arrays.asList(delegate
+                        .getEnabledProtocols()));
+                if (enabledProtocols.size() > 1) {
+                    enabledProtocols.remove("SSLv3");
+                    System.out.println("Removed SSLv3 from enabled protocols");
+                } else {
+                    System.out.println("SSL stuck with protocol available for "
+                            + String.valueOf(enabledProtocols));
+                }
+                protocols = enabledProtocols.toArray(new String[enabledProtocols.size()]);
+            }
+
+            super.setEnabledProtocols(protocols);
+        }
+    }
+
+    public class DelegateSSLSocket extends SSLSocket {
+
+        protected final SSLSocket delegate;
+
+        DelegateSSLSocket(SSLSocket delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public String[] getSupportedCipherSuites() {
+            return delegate.getSupportedCipherSuites();
+        }
+
+        @Override
+        public String[] getEnabledCipherSuites() {
+            return delegate.getEnabledCipherSuites();
+        }
+
+        @Override
+        public void setEnabledCipherSuites(String[] suites) {
+            delegate.setEnabledCipherSuites(suites);
+        }
+
+        @Override
+        public String[] getSupportedProtocols() {
+            return delegate.getSupportedProtocols();
+        }
+
+        @Override
+        public String[] getEnabledProtocols() {
+            return delegate.getEnabledProtocols();
+        }
+
+        @Override
+        public void setEnabledProtocols(String[] protocols) {
+            delegate.setEnabledProtocols(protocols);
+        }
+
+        @Override
+        public SSLSession getSession() {
+            return delegate.getSession();
+        }
+
+        @Override
+        public void addHandshakeCompletedListener(HandshakeCompletedListener listener) {
+            delegate.addHandshakeCompletedListener(listener);
+        }
+
+        @Override
+        public void removeHandshakeCompletedListener(HandshakeCompletedListener listener) {
+            delegate.removeHandshakeCompletedListener(listener);
+        }
+
+        @Override
+        public void startHandshake() throws IOException {
+            delegate.startHandshake();
+        }
+
+        @Override
+        public void setUseClientMode(boolean mode) {
+            delegate.setUseClientMode(mode);
+        }
+
+        @Override
+        public boolean getUseClientMode() {
+            return delegate.getUseClientMode();
+        }
+
+        @Override
+        public void setNeedClientAuth(boolean need) {
+            delegate.setNeedClientAuth(need);
+        }
+
+        @Override
+        public void setWantClientAuth(boolean want) {
+            delegate.setWantClientAuth(want);
+        }
+
+        @Override
+        public boolean getNeedClientAuth() {
+            return delegate.getNeedClientAuth();
+        }
+
+        @Override
+        public boolean getWantClientAuth() {
+            return delegate.getWantClientAuth();
+        }
+
+        @Override
+        public void setEnableSessionCreation(boolean flag) {
+            delegate.setEnableSessionCreation(flag);
+        }
+
+        @Override
+        public boolean getEnableSessionCreation() {
+            return delegate.getEnableSessionCreation();
+        }
+
+        @Override
+        public void bind(SocketAddress localAddr) throws IOException {
+            delegate.bind(localAddr);
+        }
+
+        @Override
+        public synchronized void close() throws IOException {
+            delegate.close();
+        }
+
+        @Override
+        public void connect(SocketAddress remoteAddr) throws IOException {
+            delegate.connect(remoteAddr);
+        }
+
+        @Override
+        public void connect(SocketAddress remoteAddr, int timeout) throws IOException {
+            delegate.connect(remoteAddr, timeout);
+        }
+
+        @Override
+        public SocketChannel getChannel() {
+            return delegate.getChannel();
+        }
+
+        @Override
+        public InetAddress getInetAddress() {
+            return delegate.getInetAddress();
+        }
+
+        @Override
+        public InputStream getInputStream() throws IOException {
+            return delegate.getInputStream();
+        }
+
+        @Override
+        public boolean getKeepAlive() throws SocketException {
+            return delegate.getKeepAlive();
+        }
+
+        @Override
+        public InetAddress getLocalAddress() {
+            return delegate.getLocalAddress();
+        }
+
+        @Override
+        public int getLocalPort() {
+            return delegate.getLocalPort();
+        }
+
+        @Override
+        public SocketAddress getLocalSocketAddress() {
+            return delegate.getLocalSocketAddress();
+        }
+
+        @Override
+        public boolean getOOBInline() throws SocketException {
+            return delegate.getOOBInline();
+        }
+
+        @Override
+        public OutputStream getOutputStream() throws IOException {
+            return delegate.getOutputStream();
+        }
+
+        @Override
+        public int getPort() {
+            return delegate.getPort();
+        }
+
+        @Override
+        public synchronized int getReceiveBufferSize() throws SocketException {
+            return delegate.getReceiveBufferSize();
+        }
+
+        @Override
+        public SocketAddress getRemoteSocketAddress() {
+            return delegate.getRemoteSocketAddress();
+        }
+
+        @Override
+        public boolean getReuseAddress() throws SocketException {
+            return delegate.getReuseAddress();
+        }
+
+        @Override
+        public synchronized int getSendBufferSize() throws SocketException {
+            return delegate.getSendBufferSize();
+        }
+
+        @Override
+        public int getSoLinger() throws SocketException {
+            return delegate.getSoLinger();
+        }
+
+        @Override
+        public synchronized int getSoTimeout() throws SocketException {
+            return delegate.getSoTimeout();
+        }
+
+        @Override
+        public boolean getTcpNoDelay() throws SocketException {
+            return delegate.getTcpNoDelay();
+        }
+
+        @Override
+        public int getTrafficClass() throws SocketException {
+            return delegate.getTrafficClass();
+        }
+
+        @Override
+        public boolean isBound() {
+            return delegate.isBound();
+        }
+
+        @Override
+        public boolean isClosed() {
+            return delegate.isClosed();
+        }
+
+        @Override
+        public boolean isConnected() {
+            return delegate.isConnected();
+        }
+
+        @Override
+        public boolean isInputShutdown() {
+            return delegate.isInputShutdown();
+        }
+
+        @Override
+        public boolean isOutputShutdown() {
+            return delegate.isOutputShutdown();
+        }
+
+        @Override
+        public void sendUrgentData(int value) throws IOException {
+            delegate.sendUrgentData(value);
+        }
+
+        @Override
+        public void setKeepAlive(boolean keepAlive) throws SocketException {
+            delegate.setKeepAlive(keepAlive);
+        }
+
+        @Override
+        public void setOOBInline(boolean oobinline) throws SocketException {
+            delegate.setOOBInline(oobinline);
+        }
+
+        @Override
+        public void setPerformancePreferences(int connectionTime, int latency, int bandwidth) {
+            delegate.setPerformancePreferences(connectionTime, latency, bandwidth);
+        }
+
+        @Override
+        public synchronized void setReceiveBufferSize(int size) throws SocketException {
+            delegate.setReceiveBufferSize(size);
+        }
+
+        @Override
+        public void setReuseAddress(boolean reuse) throws SocketException {
+            delegate.setReuseAddress(reuse);
+        }
+
+        @Override
+        public synchronized void setSendBufferSize(int size) throws SocketException {
+            delegate.setSendBufferSize(size);
+        }
+
+        @Override
+        public void setSoLinger(boolean on, int timeout) throws SocketException {
+            delegate.setSoLinger(on, timeout);
+        }
+
+        @Override
+        public synchronized void setSoTimeout(int timeout) throws SocketException {
+            delegate.setSoTimeout(timeout);
+        }
+
+        @Override
+        public void setTcpNoDelay(boolean on) throws SocketException {
+            delegate.setTcpNoDelay(on);
+        }
+
+        @Override
+        public void setTrafficClass(int value) throws SocketException {
+            delegate.setTrafficClass(value);
+        }
+
+        @Override
+        public void shutdownInput() throws IOException {
+            delegate.shutdownInput();
+        }
+
+        @Override
+        public void shutdownOutput() throws IOException {
+            delegate.shutdownOutput();
+        }
+
+        @Override
+        public String toString() {
+            return delegate.toString();
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            return delegate.equals(o);
+        }
+    }
+}

--- a/libnetcipher/src/info/guardianproject/netcipher/TlsOnlySocketFactory.java
+++ b/libnetcipher/src/info/guardianproject/netcipher/TlsOnlySocketFactory.java
@@ -27,7 +27,6 @@ import java.net.SocketException;
 import java.nio.channels.SocketChannel;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
 
 import javax.net.ssl.HandshakeCompletedListener;
 import javax.net.ssl.HttpsURLConnection;
@@ -105,25 +104,13 @@ public class TlsOnlySocketFactory extends SSLSocketFactory {
         private TlsOnlySSLSocket(SSLSocket delegate) {
             super(delegate);
 
-        }
-
-        @Override
-        public void setEnabledProtocols(String[] protocols) {
-            if (protocols != null && protocols.length == 1 && "SSLv3".equals(protocols[0])) {
-
-                List<String> enabledProtocols = new ArrayList<String>(Arrays.asList(delegate
-                        .getEnabledProtocols()));
-                if (enabledProtocols.size() > 1) {
-                    enabledProtocols.remove("SSLv3");
-                    System.out.println("Removed SSLv3 from enabled protocols");
-                } else {
-                    System.out.println("SSL stuck with protocol available for "
-                            + String.valueOf(enabledProtocols));
-                }
-                protocols = enabledProtocols.toArray(new String[enabledProtocols.size()]);
-            }
-
-            super.setEnabledProtocols(protocols);
+            // 16-19 support v1.1 and v1.2 but only by default starting in 20+
+            // https://developer.android.com/reference/javax/net/ssl/SSLSocket.html
+            ArrayList<String> protocols = new ArrayList<String>(Arrays.asList(delegate
+                    .getSupportedProtocols()));
+            protocols.remove("SSLv2");
+            protocols.remove("SSLv3");
+            super.setEnabledProtocols(protocols.toArray(new String[protocols.size()]));
         }
     }
 

--- a/netciphertest/AndroidManifest.xml
+++ b/netciphertest/AndroidManifest.xml
@@ -5,7 +5,7 @@
     android:versionName="1.0" >
 
     <uses-sdk
-        android:minSdkVersion="8"
+        android:minSdkVersion="9"
         android:targetSdkVersion="22" />
 
     <instrumentation

--- a/netciphertest/AndroidManifest.xml
+++ b/netciphertest/AndroidManifest.xml
@@ -4,35 +4,21 @@
     android:versionCode="1"
     android:versionName="1.0" >
 
-    <uses-sdk android:minSdkVersion="11" />
-    
-	<uses-permission android:name="android.permission.INTERNET" />
+    <uses-sdk
+        android:minSdkVersion="8"
+        android:targetSdkVersion="22" />
 
     <instrumentation
         android:name="android.test.InstrumentationTestRunner"
-        android:targetPackage="info.guardianproject.onionkit" />
+        android:targetPackage="info.guardianproject.onionkit.test" />
+
+    <uses-permission android:name="android.permission.INTERNET" />
 
     <application
+        android:allowBackup="false"
         android:icon="@drawable/ic_launcher"
-        android:label="@string/app_name"
-        android:theme="@android:style/Theme.Holo" >
+        android:label="@string/app_name" >
         <uses-library android:name="android.test.runner" />
-        
-            <activity
-            android:name=".TLSPretenseClientActivity"
-            android:configChanges="keyboardHidden|orientation"
-            android:label="@string/title_activity_onion_kit_sample" >
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
-        </activity>
-          <activity android:name="info.guardianproject.onionkit.ui.CertDisplayActivity"
-            android:configChanges="locale|screenSize|orientation"
-         	android:theme="@android:style/Theme.Holo.Dialog"
-         	 android:taskAffinity=""
-            />
     </application>
 
 </manifest>

--- a/netciphertest/src/info/guardianproject/netcipher/HttpURLConnectionTest.java
+++ b/netciphertest/src/info/guardianproject/netcipher/HttpURLConnectionTest.java
@@ -58,7 +58,7 @@ public class HttpURLConnectionTest extends InstrumentationTestCase {
         try {
             HttpURLConnection http = NetCipher.getHttpURLConnection(new URL(
                     "http://127.0.0.1:63453"));
-            http.setConnectTimeout(1000);
+            http.setConnectTimeout(0); // blocking connect with TCP timeout
             http.connect();
             fail();
         } catch (IOException e) {
@@ -72,7 +72,7 @@ public class HttpURLConnectionTest extends InstrumentationTestCase {
         try {
             HttpsURLConnection https = NetCipher.getHttpsURLConnection(new URL(
                     "https://127.0.0.1:63453"));
-            https.setConnectTimeout(1000);
+            https.setConnectTimeout(0); // blocking connect with TCP timeout
             https.connect();
             fail();
         } catch (IOException e) {
@@ -97,6 +97,7 @@ public class HttpURLConnectionTest extends InstrumentationTestCase {
             URL url = new URL("https://" + host);
             System.out.println("default " + url + " =================================");
             HttpsURLConnection connection = (HttpsURLConnection) url.openConnection();
+            connection.setConnectTimeout(0); // blocking connect with TCP timeout
             connection.setReadTimeout(20000);
             connection.getContent();
             assertEquals(200, connection.getResponseCode());
@@ -123,6 +124,7 @@ public class HttpURLConnectionTest extends InstrumentationTestCase {
             URL url = new URL("https://" + host);
             System.out.println("netcipher " + url + " =================================");
             HttpsURLConnection connection = NetCipher.getHttpsURLConnection(url);
+            connection.setConnectTimeout(0); // blocking connect with TCP timeout
             connection.setReadTimeout(20000);
             SSLSocketFactory sslSocketFactory = connection.getSSLSocketFactory();
             assertTrue(sslSocketFactory instanceof TlsOnlySocketFactory);
@@ -149,6 +151,7 @@ public class HttpURLConnectionTest extends InstrumentationTestCase {
             URL url = new URL("https://" + host);
             System.out.println("outdated " + url + " =================================");
             HttpsURLConnection connection = NetCipher.getCompatibleHttpsURLConnection(url);
+            connection.setConnectTimeout(0); // blocking connect with TCP timeout
             connection.setReadTimeout(20000);
             SSLSocketFactory sslSocketFactory = connection.getSSLSocketFactory();
             assertTrue(sslSocketFactory instanceof TlsOnlySocketFactory);

--- a/netciphertest/src/info/guardianproject/netcipher/HttpURLConnectionTest.java
+++ b/netciphertest/src/info/guardianproject/netcipher/HttpURLConnectionTest.java
@@ -1,0 +1,96 @@
+
+package info.guardianproject.netcipher;
+
+import android.test.InstrumentationTestCase;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.URL;
+import java.security.KeyManagementException;
+
+import javax.net.ssl.HttpsURLConnection;
+
+public class HttpURLConnectionTest extends InstrumentationTestCase {
+
+    private static final String HTTP_URL_STRING = "http://127.0.0.1:";
+    private static final String HTTPS_URL_STRING = "https://127.0.0.1:";
+
+    public void testConnectHttp() throws MalformedURLException, IOException {
+        // include trailing \n in test string, otherwise it gets added anyhow
+        final String content = "content!";
+        final String httpResponse = "HTTP/1.1 200 OK\nContent-Type: text/plain\n\n" + content;
+        final ServerSocket serverSocket = new ServerSocket(0); // auto-assign
+        final int port = serverSocket.getLocalPort();
+        new Thread() {
+            @Override
+            public void run() {
+                try {
+                    Socket s = serverSocket.accept();
+                    OutputStream os = s.getOutputStream();
+                    os.write(httpResponse.getBytes());
+                    os.flush();
+                    os.close();
+                    serverSocket.close();
+                } catch (IOException e) {
+                    e.printStackTrace();
+                    fail();
+                }
+            }
+        }.start();
+        HttpURLConnection connection = NetCipher.getHttpURLConnection(new URL(HTTP_URL_STRING
+                + port));
+        InputStream is = (InputStream) connection.getContent();
+        byte buffer[] = new byte[256];
+        int read = is.read(buffer);
+        String msg = new String(buffer, 0, read);
+        assertEquals(content, msg);
+        assertEquals(200, connection.getResponseCode());
+        assertEquals("text/plain", connection.getContentType());
+        connection.disconnect();
+    }
+
+    public void testCannotConnectHttp() throws MalformedURLException {
+        try {
+            HttpURLConnection http = NetCipher.getHttpURLConnection(new URL(
+                    "http://127.0.0.1:63453"));
+            http.setConnectTimeout(1000);
+            http.connect();
+            fail();
+        } catch (IOException e) {
+            // this should not connect
+        }
+    }
+
+    public void testCannotConnectHttps() throws MalformedURLException, KeyManagementException {
+        // TODO test connecting to http://
+        // TODO test connecting to non-HTTPS port
+        try {
+            HttpsURLConnection https = NetCipher.getHttpsURLConnection(new URL(
+                    "https://127.0.0.1:63453"));
+            https.setConnectTimeout(1000);
+            https.connect();
+            fail();
+        } catch (IOException e) {
+            // this should not connect
+        }
+    }
+
+    public void testConnectHttps() throws MalformedURLException, IOException,
+            KeyManagementException {
+        String[] hosts = {
+                "www.google.com",
+                "firstlook.org",
+        };
+        for (String host : hosts) {
+            URL url = new URL("https://" + host);
+            HttpsURLConnection https = NetCipher.getHttpsURLConnection(url);
+            https.connect();
+            https.disconnect();
+        }
+    }
+}

--- a/sample/AndroidManifest.xml
+++ b/sample/AndroidManifest.xml
@@ -4,7 +4,7 @@
     android:versionName="1.0" >
 
     <uses-sdk
-        android:minSdkVersion="8"
+        android:minSdkVersion="9"
         android:targetSdkVersion="22" />
 
         <uses-permission android:name="android.permission.INTERNET" />


### PR DESCRIPTION
Android has recommended using `HttpURLConnection` for HTTP networking since `android-9`.  This pull request creates a new set of NetCipher methods that make it easy to get an `HttpURLConnection` that is configured using modern, best practices protocols and ciphers (i.e. no SSLv3 or EXPORT ciphers).