### PR TITLE
Fix "Socket closed" error

### DIFF
--- a/sample/src/sample/netcipher/NetCipherSampleActivity.java
+++ b/sample/src/sample/netcipher/NetCipherSampleActivity.java
@@ -1,20 +1,6 @@
 
 package sample.netcipher;
 
-import info.guardianproject.netcipher.client.StrongHttpsClient;
-import info.guardianproject.netcipher.proxy.OrbotHelper;
-
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.net.Proxy;
-import java.security.KeyManagementException;
-import java.security.KeyStoreException;
-import java.security.NoSuchAlgorithmException;
-import java.security.UnrecoverableKeyException;
-import java.security.cert.CertificateException;
-
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.BroadcastReceiver;
@@ -32,8 +18,22 @@ import android.view.View.OnClickListener;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.TextView;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.Proxy;
+import java.security.KeyManagementException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.CertificateException;
+
 import ch.boye.httpclientandroidlib.HttpResponse;
 import ch.boye.httpclientandroidlib.client.methods.HttpGet;
+import info.guardianproject.netcipher.client.StrongHttpsClient;
+import info.guardianproject.netcipher.proxy.OrbotHelper;
 
 public class NetCipherSampleActivity extends Activity {
 
@@ -160,7 +160,6 @@ public class NetCipherSampleActivity extends Activity {
 
         HttpGet httpget = new HttpGet(url);
         HttpResponse response = httpclient.execute(httpget);
-        httpclient.close();
 
         StringBuffer sb = new StringBuffer();
         sb.append(response.getStatusLine()).append("\n\n");
@@ -174,6 +173,7 @@ public class NetCipherSampleActivity extends Activity {
         while ((line = br.readLine()) != null)
             sb.append(line);
 
+        httpclient.close();
         return sb.toString();
     }
 


### PR DESCRIPTION
Without this change, on Android 4.4.2 I get the following error:

```
E/NetCipherSampleActivity﹕ error connecting to: https://duckduckgo.com/?q=what+is+my+ip=java.net.SocketException: Socket is closed
    java.net.SocketException: Socket is closed
            at com.android.org.conscrypt.OpenSSLSocketImpl.checkOpen(OpenSSLSocketImpl.java:238)
            at com.android.org.conscrypt.OpenSSLSocketImpl.access$100(OpenSSLSocketImpl.java:63)
            at com.android.org.conscrypt.OpenSSLSocketImpl$SSLInputStream.read(OpenSSLSocketImpl.java:684)
            at ch.boye.httpclientandroidlib.impl.io.AbstractSessionInputBuffer.fillBuffer(AbstractSessionInputBuffer.java:160)
            at ch.boye.httpclientandroidlib.impl.io.SocketInputBuffer.fillBuffer(SocketInputBuffer.java:84)
            at ch.boye.httpclientandroidlib.impl.io.AbstractSessionInputBuffer.read(AbstractSessionInputBuffer.java:206)
            at ch.boye.httpclientandroidlib.impl.io.ChunkedInputStream.read(ChunkedInputStream.java:174)
            at ch.boye.httpclientandroidlib.conn.EofSensorInputStream.read(EofSensorInputStream.java:137)
            at java.io.InputStreamReader.read(InputStreamReader.java:233)
            at java.io.BufferedReader.fillBuf(BufferedReader.java:145)
            at java.io.BufferedReader.readLine(BufferedReader.java:397)
            at sample.netcipher.NetCipherSampleActivity.checkHTTP(NetCipherSampleActivity.java:174)
            at sample.netcipher.NetCipherSampleActivity$6.run(NetCipherSampleActivity.java:202)
            at java.lang.Thread.run(Thread.java:841)
```