### PR TITLE
Fix a bug where resetting the proxy in WebkitProxy does not work properly

### DIFF
--- a/libnetcipher/src/info/guardianproject/netcipher/web/WebkitProxy.java
+++ b/libnetcipher/src/info/guardianproject/netcipher/web/WebkitProxy.java
@@ -106,6 +106,27 @@ public class WebkitProxy {
 
     }
 
+    private static void resetSystemProperties()
+    {
+
+        System.setProperty("proxyHost", "");
+        System.setProperty("proxyPort", "");
+
+        System.setProperty("http.proxyHost", "");
+        System.setProperty("http.proxyPort", "");
+
+        System.setProperty("https.proxyHost", "");
+        System.setProperty("https.proxyPort", "");
+
+
+        System.setProperty("socks.proxyHost", "");
+        System.setProperty("socks.proxyPort", DEFAULT_SOCKS_PORT + "");
+
+        System.setProperty("socksProxyHost", "");
+        System.setProperty("socksProxyPort", DEFAULT_SOCKS_PORT + "");
+
+    }
+
     /**
      * Override WebKit Proxy settings
      * 
@@ -627,15 +648,10 @@ private static Object getFieldValueSafely(Field field, Object classInstance) thr
     }**/
 
     public static void resetProxy(String appClass, Context ctx) throws Exception {
-    	
 
-        System.clearProperty("http.proxyHost");
-        System.clearProperty("http.proxyPort");
-        System.clearProperty("https.proxyHost");
-        System.clearProperty("https.proxyPort");
-        
-        
-         if (Build.VERSION.SDK_INT < 14)
+        resetSystemProperties();
+
+        if (Build.VERSION.SDK_INT < 14)
         {
             resetProxyForGingerBread(ctx);
         }
@@ -645,7 +661,7 @@ private static Object getFieldValueSafely(Field field, Object classInstance) thr
         }
         else
         {
-        	resetKitKatProxy(appClass, ctx);
+            resetKitKatProxy(appClass, ctx);
         }
          
     }


### PR DESCRIPTION
Currently, calling resetProxy() does not actually reset the proxy as not all of the system properties were being reset and the WebView still tries to connect through the proxy. This is problematic if the user switches off using the proxy and turns off Orbot and does not restart the app. In this case, the app will be unable to load data as some of the system properties are still pointing to localhost and will not be reset until the app is restarted.

Resetting all these properties correctly allows the proxy to be reset without the application needing to be restarted.