### PR TITLE
Add Support for Testing from Gradle

### DIFF
--- a/libnetcipher/build.gradle
+++ b/libnetcipher/build.gradle
@@ -21,6 +21,16 @@ android {
             res.srcDirs = ['res']
             assets.srcDirs = ['assets']
         }
+
+        androidTest {
+            manifest.srcFile '../netciphertest/AndroidManifest.xml'
+            java.srcDirs = ['../netciphertest/src']
+            resources.srcDirs = ['../netciphertest/src']
+            aidl.srcDirs = ['../netciphertest/src']
+            renderscript.srcDirs = ['../netciphertest/src']
+            res.srcDirs = ['../netciphertest/res']
+            assets.srcDirs = ['../netciphertest/assets']
+        }
     }
 
 	lintOptions {

--- a/netciphertest/src/info/guardianproject/netcipher/HttpURLConnectionTest.java
+++ b/netciphertest/src/info/guardianproject/netcipher/HttpURLConnectionTest.java
@@ -32,6 +32,7 @@ import java.security.NoSuchAlgorithmException;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocketFactory;
+import info.guardianproject.netcipher.client.TlsOnlySocketFactory;
 
 public class HttpURLConnectionTest extends InstrumentationTestCase {
 

--- a/netciphertest/src/info/guardianproject/onionkit/test/TLSPretenseClientActivity.java
+++ b/netciphertest/src/info/guardianproject/onionkit/test/TLSPretenseClientActivity.java
@@ -30,7 +30,7 @@ import android.widget.TextView;
 
 import ch.boye.httpclientandroidlib.HttpResponse;
 import ch.boye.httpclientandroidlib.client.methods.HttpGet;
-import info.guardianproject.onionkit.trust.StrongHttpsClient;
+import info.guardianproject.netcipher.client.StrongHttpsClient;
 
 import java.io.IOException;
 import java.io.InputStream;


### PR DESCRIPTION
The `build.gradle` changes work, though [I am trying to find a cleaner approach](http://stackoverflow.com/questions/36294952/how-do-we-point-androidtest-to-a-peer-eclipse-style-project).

I'm a relative newcomer to GitHub pull requests, so my apologies if there are any problems with what I've done here.