### PR TITLE
Enable SNI

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0-rc1'
+        classpath 'com.android.tools.build:gradle:2.0.0'
     }
 }
 

--- a/libnetcipher/src/info/guardianproject/netcipher/client/TlsOnlySocketFactory.java
+++ b/libnetcipher/src/info/guardianproject/netcipher/client/TlsOnlySocketFactory.java
@@ -20,6 +20,7 @@
 package info.guardianproject.netcipher.client;
 
 import android.net.SSLCertificateSocketFactory;
+import android.os.Build;
 import android.util.Log;
 
 import java.io.IOException;
@@ -90,7 +91,19 @@ public class TlsOnlySocketFactory extends SSLSocketFactory {
 
     private Socket makeSocketSafe(Socket socket, String host) {
         if (socket instanceof SSLSocket) {
-            socket = new TlsOnlySSLSocket((SSLSocket) socket, compatible).setHostname(host);
+            TlsOnlySSLSocket tempSocket=
+              new TlsOnlySSLSocket((SSLSocket) socket, compatible);
+
+            if (delegate instanceof SSLCertificateSocketFactory &&
+              Build.VERSION.SDK_INT>=Build.VERSION_CODES.JELLY_BEAN_MR1) {
+                ((android.net.SSLCertificateSocketFactory)delegate)
+                  .setHostname(socket, host);
+            }
+            else {
+                tempSocket.setHostname(host);
+            }
+
+            socket = tempSocket;
         }
         return socket;
     }

--- a/libnetcipher/src/info/guardianproject/netcipher/client/TlsOnlySocketFactory.java
+++ b/libnetcipher/src/info/guardianproject/netcipher/client/TlsOnlySocketFactory.java
@@ -19,6 +19,7 @@
 
 package info.guardianproject.netcipher.client;
 
+import android.net.SSLCertificateSocketFactory;
 import android.util.Log;
 
 import java.io.IOException;
@@ -51,12 +52,13 @@ import javax.net.ssl.SSLSocketFactory;
  * @author Hans-Christoph Steiner
  */
 public class TlsOnlySocketFactory extends SSLSocketFactory {
+    private static final int HANDSHAKE_TIMEOUT=0;
     private static final String TAG = "TlsOnlySocketFactory";
     private final SSLSocketFactory delegate;
     private final boolean compatible;
 
     public TlsOnlySocketFactory() {
-        this.delegate = HttpsURLConnection.getDefaultSSLSocketFactory();
+        this.delegate =SSLCertificateSocketFactory.getDefault(HANDSHAKE_TIMEOUT, null);
         this.compatible = false;
     }
 

--- a/netciphertest/src/info/guardianproject/netcipher/HttpURLConnectionTest.java
+++ b/netciphertest/src/info/guardianproject/netcipher/HttpURLConnectionTest.java
@@ -111,7 +111,7 @@ public class HttpURLConnectionTest extends InstrumentationTestCase {
                 "www.google.com",
                 "glympse.com",
                 // uses SNI
-                //"firstlook.org",
+                "firstlook.org",
                 //"guardianproject.info",
         };
         // reset the default SSLSocketFactory, since it is global
@@ -145,7 +145,7 @@ public class HttpURLConnectionTest extends InstrumentationTestCase {
                 "www.google.com",
                 "glympse.com",
                 // uses SNI
-                //"firstlook.org",
+                "firstlook.org",
                 //"guardianproject.info",
         };
         for (String host : hosts) {
@@ -174,7 +174,7 @@ public class HttpURLConnectionTest extends InstrumentationTestCase {
                 "goo.gl",
                 "www.google.com",
                 // uses SNI
-                //"firstlook.org",
+                "firstlook.org",
                 //"guardianproject.info",
         };
         for (String host : hosts) {


### PR DESCRIPTION
`TlsOnlySocketFactory` now uses `android.net.SSLCertificateSocketFactory` as the default delegate. However, this is of little use, as most of our scenarios will involve passing in an `SSLSocketFactory` culled from an `SSLContext`. For whatever reason, the `SSLSocketFactory` that `SSLContext#getSocketFactory()` returns does *not* appear to be rooted in `SSLCertificateSocketFactory`. Leastways, SNI does not work with just that change, based on the unit tests.

So, I introduced the `setHostname()` hack, based on the K9-Mail implementation. SNI now works, at least on Android 5.1, 6.0, and (FWIW) the N Developer Preview 1.

I re-enabled firstlook.org for the SNI tests; it was unclear to me if guardianproject.info uses SNI or if there was another reason it was commented out.