### PR TITLE
OrbotHelper: Manage Broadcasts to Orbot

### DIFF
--- a/libnetcipher/AndroidManifest.xml
+++ b/libnetcipher/AndroidManifest.xml
@@ -3,6 +3,6 @@
     android:versionCode="12"
     android:versionName="1.2">
 
-    <uses-sdk android:minSdkVersion="8" android:targetSdkVersion="22" />
+    <uses-sdk android:minSdkVersion="9" android:targetSdkVersion="22" />
 
 </manifest>

--- a/libnetcipher/AndroidManifest.xml
+++ b/libnetcipher/AndroidManifest.xml
@@ -3,6 +3,6 @@
     android:versionCode="12"
     android:versionName="1.2">
 
-    <uses-sdk android:minSdkVersion="9" android:targetSdkVersion="22" />
+    <uses-sdk android:minSdkVersion="8" android:targetSdkVersion="22" />
 
 </manifest>

--- a/libnetcipher/src/info/guardianproject/netcipher/proxy/OrbotHelper.java
+++ b/libnetcipher/src/info/guardianproject/netcipher/proxy/OrbotHelper.java
@@ -36,6 +36,7 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.WeakHashMap;
 
@@ -316,9 +317,9 @@ public class OrbotHelper implements ProxyHelper {
     private boolean isInstalled=false;
     private Intent lastStatusIntent=null;
     private Set<StatusCallback> statusCallbacks=
-      Collections.newSetFromMap(new WeakHashMap<StatusCallback, Boolean>());
+      newSetFromMap(new WeakHashMap<StatusCallback, Boolean>());
     private Set<InstallCallback> installCallbacks=
-      Collections.newSetFromMap(new WeakHashMap<InstallCallback, Boolean>());
+      newSetFromMap(new WeakHashMap<InstallCallback, Boolean>());
     private long statusTimeoutMs=30000L;
     private long installTimeoutMs=60000L;
 
@@ -632,4 +633,27 @@ public class OrbotHelper implements ProxyHelper {
         }
     };
 
+    /*
+     *  Licensed to the Apache Software Foundation (ASF) under one or more
+     *  contributor license agreements.  See the NOTICE file distributed with
+     *  this work for additional information regarding copyright ownership.
+     *  The ASF licenses this file to You under the Apache License, Version 2.0
+     *  (the "License"); you may not use this file except in compliance with
+     *  the License.  You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     *  Unless required by applicable law or agreed to in writing, software
+     *  distributed under the License is distributed on an "AS IS" BASIS,
+     *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     *  See the License for the specific language governing permissions and
+     *  limitations under the License.
+     */
+
+    static <E> Set<E> newSetFromMap(Map<E, Boolean> map) {
+        if (map.isEmpty()) {
+            return new SetFromMap<E>(map);
+        }
+        throw new IllegalArgumentException("map not empty");
+    }
 }

--- a/libnetcipher/src/info/guardianproject/netcipher/proxy/OrbotHelper.java
+++ b/libnetcipher/src/info/guardianproject/netcipher/proxy/OrbotHelper.java
@@ -1,6 +1,7 @@
 /*
  * Copyright 2014-2016 Hans-Christoph Steiner
  * Copyright 2012-2016 Nathan Freitas
+ * Portions Copyright (c) 2016 CommonsWare, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,18 +19,37 @@
 package info.guardianproject.netcipher.proxy;
 
 import android.app.Activity;
+import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import android.content.IntentFilter;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.net.Uri;
+import android.os.Handler;
+import android.os.Looper;
 import android.text.TextUtils;
 import android.util.Log;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
+import java.util.WeakHashMap;
 
+/**
+ * Utility class to simplify setting up a proxy connection
+ * to Orbot.
+ *
+ * If you are using classes in the info.guardianproject.netcipher.client
+ * package, call OrbotHelper.get(this).init(); from onCreate()
+ * of a custom Application subclass, or from some other guaranteed
+ * entry point to your app. At that point, the
+ * info.guardianproject.netcipher.client classes will be ready
+ * for use.
+ */
 public class OrbotHelper implements ProxyHelper {
 
     private final static int REQUEST_CODE_STATUS = 100;
@@ -83,9 +103,11 @@ public class OrbotHelper implements ProxyHelper {
     public final static int HS_REQUEST_CODE = 9999;
 
 
+/*
     private OrbotHelper() {
         // only static utility methods, do not instantiate
     }
+*/
 
     /**
      * Test whether a {@link URL} is a Tor Hidden Service host name, also known
@@ -286,4 +308,328 @@ public class OrbotHelper implements ProxyHelper {
 	public String getName() {
 		return "Orbot";
 	}
+
+    /* MLM additions */
+
+    private final Context ctxt;
+    private final Handler handler;
+    private boolean isInstalled=false;
+    private Intent lastStatusIntent=null;
+    private Set<StatusCallback> statusCallbacks=
+      Collections.newSetFromMap(new WeakHashMap<StatusCallback, Boolean>());
+    private Set<InstallCallback> installCallbacks=
+      Collections.newSetFromMap(new WeakHashMap<InstallCallback, Boolean>());
+    private long statusTimeoutMs=30000L;
+    private long installTimeoutMs=60000L;
+
+    abstract public static class SimpleStatusCallback
+      implements StatusCallback {
+        @Override
+        public void onEnabled(Intent statusIntent) {
+            // no-op; extend and override if needed
+        }
+
+        @Override
+        public void onStarting() {
+            // no-op; extend and override if needed
+        }
+
+        @Override
+        public void onStopping() {
+            // no-op; extend and override if needed
+        }
+
+        @Override
+        public void onDisabled() {
+            // no-op; extend and override if needed
+        }
+
+        @Override
+        public void onNotYetInstalled() {
+            // no-op; extend and override if needed
+        }
+    }
+
+    /**
+     * Callback interface used for reporting the results of an
+     * attempt to install Orbot
+     */
+    public interface InstallCallback {
+        void onInstalled();
+        void onInstallTimeout();
+    }
+
+    private static volatile OrbotHelper INSTANCE;
+
+    /**
+     * Retrieves the singleton, initializing if if needed
+     *
+     * @param ctxt any Context will do, as we will hold onto
+     *             the Application
+     * @return the singleton
+     */
+    synchronized public static OrbotHelper get(Context ctxt) {
+        if (INSTANCE==null) {
+            INSTANCE=new OrbotHelper(ctxt);
+        }
+
+        return(INSTANCE);
+    }
+
+    /**
+     * Standard constructor
+     *
+     * @param ctxt any Context will do; OrbotInitializer will hold
+     *             onto the Application context
+     */
+    private OrbotHelper(Context ctxt) {
+        this.ctxt=ctxt.getApplicationContext();
+        this.handler=new Handler(Looper.getMainLooper());
+    }
+
+    /**
+     * Adds a StatusCallback to be called when we find out that
+     * Orbot is ready. If Orbot is ready for use, your callback
+     * will be called with onEnabled() immediately, before this
+     * method returns.
+     *
+     * @param cb a callback
+     * @return the singleton, for chaining
+     */
+    public OrbotHelper addStatusCallback(StatusCallback cb) {
+        statusCallbacks.add(cb);
+
+        if (lastStatusIntent!=null) {
+            String status=
+              lastStatusIntent.getStringExtra(OrbotHelper.EXTRA_STATUS);
+
+            if (status.equals(OrbotHelper.STATUS_ON)) {
+                cb.onEnabled(lastStatusIntent);
+            }
+        }
+
+        return(this);
+    }
+
+    /**
+     * Removes an existing registered StatusCallback.
+     *
+     * @param cb the callback to remove
+     * @return the singleton, for chaining
+     */
+    public OrbotHelper removeStatusCallback(StatusCallback cb) {
+        statusCallbacks.remove(cb);
+
+        return(this);
+    }
+
+
+    /**
+     * Adds an InstallCallback to be called when we find out that
+     * Orbot is installed
+     *
+     * @param cb a callback
+     * @return the singleton, for chaining
+     */
+    public OrbotHelper addInstallCallback(InstallCallback cb) {
+        installCallbacks.add(cb);
+
+        return(this);
+    }
+
+    /**
+     * Removes an existing registered InstallCallback.
+     *
+     * @param cb the callback to remove
+     * @return the singleton, for chaining
+     */
+    public OrbotHelper removeInstallCallback(InstallCallback cb) {
+        installCallbacks.remove(cb);
+
+        return(this);
+    }
+
+    /**
+     * Sets how long of a delay, in milliseconds, after trying
+     * to get a status from Orbot before we give up.
+     * Defaults to 30000ms = 30 seconds = 0.000347222 days
+     *
+     * @param timeoutMs delay period in milliseconds
+     * @return the singleton, for chaining
+     */
+    public OrbotHelper statusTimeout(long timeoutMs) {
+        statusTimeoutMs=timeoutMs;
+
+        return(this);
+    }
+
+    /**
+     * Sets how long of a delay, in milliseconds, after trying
+     * to install Orbot do we assume that it's not happening.
+     * Defaults to 60000ms = 60 seconds = 1 minute = 1.90259e-6 years
+     *
+     * @param timeoutMs delay period in milliseconds
+     * @return the singleton, for chaining
+     */
+    public OrbotHelper installTimeout(long timeoutMs) {
+        installTimeoutMs=timeoutMs;
+
+        return(this);
+    }
+
+    /**
+     * @return true if Orbot is installed (the last time we checked),
+     * false otherwise
+     */
+    public boolean isInstalled() {
+        return(isInstalled);
+    }
+
+    /**
+     * Initializes the connection to Orbot, revalidating that it
+     * is installed and requesting fresh status broadcasts.
+     *
+     * @return true if initialization is proceeding, false if
+     * Orbot is not installed
+     */
+    public boolean init() {
+        Intent orbot=OrbotHelper.getOrbotStartIntent(ctxt);
+        ArrayList<String> hashes=new ArrayList<String>();
+
+        hashes.add("A4:54:B8:7A:18:47:A8:9E:D7:F5:E7:0F:BA:6B:BA:96:F3:EF:29:C2:6E:09:81:20:4F:E3:47:BF:23:1D:FD:5B");
+        hashes.add("A7:02:07:92:4F:61:FF:09:37:1D:54:84:14:5C:4B:EE:77:2C:55:C1:9E:EE:23:2F:57:70:E1:82:71:F7:CB:AE");
+
+        orbot=
+          SignatureUtils.validateBroadcastIntent(ctxt, orbot,
+            hashes, false);
+
+        if (orbot!=null) {
+            isInstalled=true;
+            handler.postDelayed(onStatusTimeout, statusTimeoutMs);
+            ctxt.registerReceiver(orbotStatusReceiver,
+              new IntentFilter(OrbotHelper.ACTION_STATUS));
+            ctxt.sendBroadcast(orbot);
+        }
+        else {
+            isInstalled=false;
+
+            for (StatusCallback cb : statusCallbacks) {
+                cb.onNotYetInstalled();
+            }
+        }
+
+        return(isInstalled);
+    }
+
+    /**
+     * Given that init() returned false, calling installOrbot()
+     * will trigger an attempt to install Orbot from an available
+     * distribution channel (e.g., the Play Store). Only call this
+     * if the user is expecting it, such as in response to tapping
+     * a dialog button or an action bar item.
+     *
+     * Note that installation may take a long time, even if
+     * the user is proceeding with the installation, due to network
+     * speeds, waiting for user input, and so on. Either specify
+     * a long timeout, or consider the timeout to be merely advisory
+     * and use some other user input to cause you to try
+     * init() again after, presumably, Orbot has been installed
+     * and configured by the user.
+     *
+     * If the user does install Orbot, we will attempt init()
+     * again automatically. Hence, you will probably need user input
+     * to tell you when the user has gotten Orbot up and going.
+     *
+     * @param host the Activity that is triggering this work
+     */
+    public void installOrbot(Activity host) {
+        handler.postDelayed(onInstallTimeout, installTimeoutMs);
+
+        IntentFilter filter=
+          new IntentFilter(Intent.ACTION_PACKAGE_ADDED);
+
+        filter.addDataScheme("package");
+
+        ctxt.registerReceiver(orbotInstallReceiver, filter);
+        host.startActivity(OrbotHelper.getOrbotInstallIntent(ctxt));
+    }
+
+    private BroadcastReceiver orbotStatusReceiver=new BroadcastReceiver() {
+        @Override
+        public void onReceive(Context ctxt, Intent intent) {
+            if (TextUtils.equals(intent.getAction(),
+              OrbotHelper.ACTION_STATUS)) {
+                String status=intent.getStringExtra(OrbotHelper.EXTRA_STATUS);
+
+                if (status.equals(OrbotHelper.STATUS_ON)) {
+                    lastStatusIntent=intent;
+                    handler.removeCallbacks(onStatusTimeout);
+
+                    for (StatusCallback cb : statusCallbacks) {
+                        cb.onEnabled(intent);
+                    }
+                }
+                else if (status.equals(OrbotHelper.STATUS_OFF)) {
+                    for (StatusCallback cb : statusCallbacks) {
+                        cb.onDisabled();
+                    }
+                }
+                else if (status.equals(OrbotHelper.STATUS_STARTING)) {
+                    for (StatusCallback cb : statusCallbacks) {
+                        cb.onStarting();
+                    }
+                }
+                else if (status.equals(OrbotHelper.STATUS_STOPPING)) {
+                    for (StatusCallback cb : statusCallbacks) {
+                        cb.onStopping();
+                    }
+                }
+            }
+        }
+    };
+
+    private Runnable onStatusTimeout=new Runnable() {
+        @Override
+        public void run() {
+            ctxt.unregisterReceiver(orbotStatusReceiver);
+
+            for (StatusCallback cb : statusCallbacks) {
+                cb.onStatusTimeout();
+            }
+        }
+    };
+
+    private BroadcastReceiver orbotInstallReceiver=new BroadcastReceiver() {
+        @Override
+        public void onReceive(Context ctxt, Intent intent) {
+            if (TextUtils.equals(intent.getAction(),
+              Intent.ACTION_PACKAGE_ADDED)) {
+                String pkgName=intent.getData().getEncodedSchemeSpecificPart();
+
+                if (OrbotHelper.ORBOT_PACKAGE_NAME.equals(pkgName)) {
+                    isInstalled=true;
+                    handler.removeCallbacks(onInstallTimeout);
+                    ctxt.unregisterReceiver(orbotInstallReceiver);
+
+                    for (InstallCallback cb : installCallbacks) {
+                        cb.onInstalled();
+                    }
+
+                    init();
+                }
+            }
+        }
+    };
+
+    private Runnable onInstallTimeout=new Runnable() {
+        @Override
+        public void run() {
+            ctxt.unregisterReceiver(orbotInstallReceiver);
+
+            for (InstallCallback cb : installCallbacks) {
+                cb.onInstallTimeout();
+            }
+        }
+    };
+
 }

--- a/libnetcipher/src/info/guardianproject/netcipher/proxy/OrbotHelper.java
+++ b/libnetcipher/src/info/guardianproject/netcipher/proxy/OrbotHelper.java
@@ -322,6 +322,7 @@ public class OrbotHelper implements ProxyHelper {
       newSetFromMap(new WeakHashMap<InstallCallback, Boolean>());
     private long statusTimeoutMs=30000L;
     private long installTimeoutMs=60000L;
+    private boolean validateOrbot=true;
 
     abstract public static class SimpleStatusCallback
       implements StatusCallback {
@@ -479,6 +480,21 @@ public class OrbotHelper implements ProxyHelper {
     }
 
     /**
+     * By default, NetCipher ensures that the Orbot on the
+     * device is one of the official builds. Call this method
+     * to skip that validation. Mostly, this is for developers
+     * who have their own custom Orbot builds (e.g., for
+     * dedicated hardware).
+     *
+     * @return the singleton, for chaining
+     */
+    public OrbotHelper skipOrbotValidation() {
+        validateOrbot=false;
+
+        return(this);
+    }
+
+    /**
      * @return true if Orbot is installed (the last time we checked),
      * false otherwise
      */
@@ -495,14 +511,17 @@ public class OrbotHelper implements ProxyHelper {
      */
     public boolean init() {
         Intent orbot=OrbotHelper.getOrbotStartIntent(ctxt);
-        ArrayList<String> hashes=new ArrayList<String>();
 
-        hashes.add("A4:54:B8:7A:18:47:A8:9E:D7:F5:E7:0F:BA:6B:BA:96:F3:EF:29:C2:6E:09:81:20:4F:E3:47:BF:23:1D:FD:5B");
-        hashes.add("A7:02:07:92:4F:61:FF:09:37:1D:54:84:14:5C:4B:EE:77:2C:55:C1:9E:EE:23:2F:57:70:E1:82:71:F7:CB:AE");
+        if (validateOrbot) {
+            ArrayList<String> hashes=new ArrayList<String>();
 
-        orbot=
-          SignatureUtils.validateBroadcastIntent(ctxt, orbot,
-            hashes, false);
+            hashes.add("A4:54:B8:7A:18:47:A8:9E:D7:F5:E7:0F:BA:6B:BA:96:F3:EF:29:C2:6E:09:81:20:4F:E3:47:BF:23:1D:FD:5B");
+            hashes.add("A7:02:07:92:4F:61:FF:09:37:1D:54:84:14:5C:4B:EE:77:2C:55:C1:9E:EE:23:2F:57:70:E1:82:71:F7:CB:AE");
+
+            orbot=
+              SignatureUtils.validateBroadcastIntent(ctxt, orbot,
+                hashes, false);
+        }
 
         if (orbot!=null) {
             isInstalled=true;

--- a/libnetcipher/src/info/guardianproject/netcipher/proxy/SetFromMap.java
+++ b/libnetcipher/src/info/guardianproject/netcipher/proxy/SetFromMap.java
@@ -1,0 +1,88 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package info.guardianproject.netcipher.proxy;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.Serializable;
+import java.util.AbstractSet;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+
+class SetFromMap<E> extends AbstractSet<E>
+  implements Serializable {
+  private static final long serialVersionUID = 2454657854757543876L;
+  // Must be named as is, to pass serialization compatibility test.
+  private final Map<E, Boolean> m;
+  private transient Set<E> backingSet;
+  SetFromMap(final Map<E, Boolean> map) {
+    m = map;
+    backingSet = map.keySet();
+  }
+  @Override public boolean equals(Object object) {
+    return backingSet.equals(object);
+  }
+  @Override public int hashCode() {
+    return backingSet.hashCode();
+  }
+  @Override public boolean add(E object) {
+    return m.put(object, Boolean.TRUE) == null;
+  }
+  @Override public void clear() {
+    m.clear();
+  }
+  @Override public String toString() {
+    return backingSet.toString();
+  }
+  @Override public boolean contains(Object object) {
+    return backingSet.contains(object);
+  }
+  @Override public boolean containsAll(Collection<?> collection) {
+    return backingSet.containsAll(collection);
+  }
+  @Override public boolean isEmpty() {
+    return m.isEmpty();
+  }
+  @Override public boolean remove(Object object) {
+    return m.remove(object) != null;
+  }
+  @Override public boolean retainAll(Collection<?> collection) {
+    return backingSet.retainAll(collection);
+  }
+  @Override public Object[] toArray() {
+    return backingSet.toArray();
+  }
+  @Override
+  public <T> T[] toArray(T[] contents) {
+    return backingSet.toArray(contents);
+  }
+  @Override public Iterator<E> iterator() {
+    return backingSet.iterator();
+  }
+  @Override public int size() {
+    return m.size();
+  }
+  @SuppressWarnings("unchecked")
+  private void readObject(ObjectInputStream stream)
+    throws IOException, ClassNotFoundException {
+    stream.defaultReadObject();
+    backingSet = m.keySet();
+  }
+}

--- a/libnetcipher/src/info/guardianproject/netcipher/proxy/SignatureUtils.java
+++ b/libnetcipher/src/info/guardianproject/netcipher/proxy/SignatureUtils.java
@@ -1,0 +1,476 @@
+/***
+  Copyright (c) 2014 CommonsWare, LLC
+  
+  Licensed under the Apache License, Version 2.0 (the "License"); you may
+  not use this file except in compliance with the License. You may obtain
+  a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+ */
+
+package info.guardianproject.netcipher.proxy;
+
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.content.pm.PackageManager.NameNotFoundException;
+import android.content.pm.ResolveInfo;
+import android.content.pm.Signature;
+import android.util.Log;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class SignatureUtils {
+  public static String getOwnSignatureHash(Context ctxt)
+                                                        throws
+    NameNotFoundException,
+    NoSuchAlgorithmException {
+    return(getSignatureHash(ctxt, ctxt.getPackageName()));
+  }
+
+  public static String getSignatureHash(Context ctxt, String packageName)
+                                                                         throws
+    NameNotFoundException,
+    NoSuchAlgorithmException {
+    MessageDigest md=MessageDigest.getInstance("SHA-256");
+    Signature sig=
+        ctxt.getPackageManager()
+            .getPackageInfo(packageName, PackageManager.GET_SIGNATURES).signatures[0];
+
+    return(toHexStringWithColons(md.digest(sig.toByteArray())));
+  }
+
+  // based on https://stackoverflow.com/a/2197650/115145
+
+  public static String toHexStringWithColons(byte[] bytes) {
+    char[] hexArray=
+        { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B',
+            'C', 'D', 'E', 'F' };
+    char[] hexChars=new char[(bytes.length * 3) - 1];
+    int v;
+
+    for (int j=0; j < bytes.length; j++) {
+      v=bytes[j] & 0xFF;
+      hexChars[j * 3]=hexArray[v / 16];
+      hexChars[j * 3 + 1]=hexArray[v % 16];
+
+      if (j < bytes.length - 1) {
+        hexChars[j * 3 + 2]=':';
+      }
+    }
+
+    return new String(hexChars);
+  }
+
+  /**
+   * Confirms that the broadcast receiver for a given Intent
+   * has the desired signature hash.
+   *
+   * If you know the package name of the receiver, call
+   * setPackage() on the Intent before passing into this method.
+   * That will validate whether the package is installed and whether
+   * it has the proper signature hash. You can distinguish between
+   * these cases by passing true for the failIfHack parameter.
+   *
+   * In general, there are three possible outcomes of calling
+   * this method:
+   *
+   * 1. You get a SecurityException, because failIfHack is true,
+   * and we found some receiver whose app does not match the
+   * desired hash. The user may have installed a repackaged
+   * version of this app that is signed by the wrong key.
+   *
+   * 2. You get null. If failIfHack is true, this means that no
+   * receiver was found that matches the Intent. If failIfHack
+   * is false, this means that no receiver was found that matches
+   * the Intent and has a valid matching signature.
+   *
+   * 3. You get an Intent. This means we found a matching receiver
+   * that has a matching signature. The Intent will be a copy of
+   * the passed-in Intent, with the component name set to the
+   * matching receiver, so the "broadcast" will only go to this
+   * one component.
+   *
+   * @param ctxt any Context will do; the value is not retained
+   * @param toValidate the Intent that you intend to broadcast
+   * @param sigHash the signature hash of the app that you expect
+   *                to handle this broadcast
+   * @param failIfHack true if you want a SecurityException if
+   *                   a matching receiver is found but it has
+   *                   the wrong signature hash, false otherwise
+   * @return null if there is no matching receiver with the correct
+   * hash, or a copy of the toValidate parameter with the full component
+   * name of the target receiver added to the Intent
+   */
+  public static Intent validateBroadcastIntent(Context ctxt,
+                                               Intent toValidate,
+                                               String sigHash,
+                                               boolean failIfHack) {
+    ArrayList<String> sigHashes=new ArrayList<String>();
+
+    sigHashes.add(sigHash);
+
+    return(validateBroadcastIntent(ctxt, toValidate, sigHashes,
+      failIfHack));
+  }
+
+  /**
+   * Confirms that the broadcast receiver for a given Intent
+   * has a desired signature hash.
+   *
+   * If you know the package name of the receiver, call
+   * setPackage() on the Intent before passing into this method.
+   * That will validate whether the package is installed and whether
+   * it has a proper signature hash. You can distinguish between
+   * these cases by passing true for the failIfHack parameter.
+   *
+   * In general, there are three possible outcomes of calling
+   * this method:
+   *
+   * 1. You get a SecurityException, because failIfHack is true,
+   * and we found some receiver whose app does not match the
+   * desired hash. The user may have installed a repackaged
+   * version of this app that is signed by the wrong key.
+   *
+   * 2. You get null. If failIfHack is true, this means that no
+   * receiver was found that matches the Intent. If failIfHack
+   * is false, this means that no receiver was found that matches
+   * the Intent and has a valid matching signature.
+   *
+   * 3. You get an Intent. This means we found a matching receiver
+   * that has a matching signature. The Intent will be a copy of
+   * the passed-in Intent, with the component name set to the
+   * matching receiver, so the "broadcast" will only go to this
+   * one component.
+   *
+   * @param ctxt any Context will do; the value is not retained
+   * @param toValidate the Intent that you intend to broadcast
+   * @param sigHashes the possible signature hashes of the app
+   *                  that you expect to handle this broadcast
+   * @param failIfHack true if you want a SecurityException if
+   *                   a matching receiver is found but it has
+   *                   the wrong signature hash, false otherwise
+   * @return null if there is no matching receiver with the correct
+   * hash, or a copy of the toValidate parameter with the full component
+   * name of the target receiver added to the Intent
+   */
+  public static Intent validateBroadcastIntent(Context ctxt,
+                                               Intent toValidate,
+                                               List<String> sigHashes,
+                                               boolean failIfHack) {
+    PackageManager pm=ctxt.getPackageManager();
+    Intent result=null;
+    List<ResolveInfo> receivers=
+      pm.queryBroadcastReceivers(toValidate, 0);
+
+    if (receivers!=null) {
+      for (ResolveInfo info : receivers) {
+        try {
+          if (sigHashes.contains(getSignatureHash(ctxt,
+            info.activityInfo.packageName))) {
+            ComponentName cn=
+              new ComponentName(info.activityInfo.packageName,
+                info.activityInfo.name);
+
+            result=new Intent(toValidate).setComponent(cn);
+            break;
+          }
+          else if (failIfHack) {
+            throw new SecurityException(
+              "Package has signature hash mismatch: "+
+                info.activityInfo.packageName);
+          }
+        }
+        catch (NoSuchAlgorithmException e) {
+          Log.w("SignatureUtils",
+            "Exception when computing signature hash", e);
+        }
+        catch (NameNotFoundException e) {
+          Log.w("SignatureUtils",
+            "Exception when computing signature hash", e);
+        }
+      }
+    }
+
+    return(result);
+  }
+
+  /**
+   * Confirms that the activity for a given Intent has the
+   * desired signature hash.
+   *
+   * If you know the package name of the activity, call
+   * setPackage() on the Intent before passing into this method.
+   * That will validate whether the package is installed and whether
+   * it has the proper signature hash. You can distinguish between
+   * these cases by passing true for the failIfHack parameter.
+   *
+   * In general, there are three possible outcomes of calling
+   * this method:
+   *
+   * 1. You get a SecurityException, because failIfHack is true,
+   * and we found some activity whose app does not match the
+   * desired hash. The user may have installed a repackaged
+   * version of this app that is signed by the wrong key.
+   *
+   * 2. You get null. If failIfHack is true, this means that no
+   * activity was found that matches the Intent. If failIfHack
+   * is false, this means that no activity was found that matches
+   * the Intent and has a valid matching signature.
+   *
+   * 3. You get an Intent. This means we found a matching activity
+   * that has a matching signature. The Intent will be a copy of
+   * the passed-in Intent, with the component name set to the
+   * matching activity, so a call to startActivity() for this
+   * Intent is guaranteed to go to this specific activity.
+   *
+   * @param ctxt any Context will do; the value is not retained
+   * @param toValidate the Intent that you intend to use with
+   *                   startActivity()
+   * @param sigHash the signature hash of the app that you expect
+   *                to handle this activity
+   * @param failIfHack true if you want a SecurityException if
+   *                   a matching activity is found but it has
+   *                   the wrong signature hash, false otherwise
+   * @return null if there is no matching activity with the correct
+   * hash, or a copy of the toValidate parameter with the full component
+   * name of the target activity added to the Intent
+   */
+  public static Intent validateActivityIntent(Context ctxt,
+                                              Intent toValidate,
+                                              String sigHash,
+                                              boolean failIfHack) {
+    ArrayList<String> sigHashes=new ArrayList<String>();
+
+    sigHashes.add(sigHash);
+
+    return(validateActivityIntent(ctxt, toValidate, sigHashes,
+      failIfHack));
+  }
+
+  /**
+   * Confirms that the activity for a given Intent has the
+   * desired signature hash.
+   *
+   * If you know the package name of the activity, call
+   * setPackage() on the Intent before passing into this method.
+   * That will validate whether the package is installed and whether
+   * it has the proper signature hash. You can distinguish between
+   * these cases by passing true for the failIfHack parameter.
+   *
+   * In general, there are three possible outcomes of calling
+   * this method:
+   *
+   * 1. You get a SecurityException, because failIfHack is true,
+   * and we found some activity whose app does not match the
+   * desired hash. The user may have installed a repackaged
+   * version of this app that is signed by the wrong key.
+   *
+   * 2. You get null. If failIfHack is true, this means that no
+   * activity was found that matches the Intent. If failIfHack
+   * is false, this means that no activity was found that matches
+   * the Intent and has a valid matching signature.
+   *
+   * 3. You get an Intent. This means we found a matching activity
+   * that has a matching signature. The Intent will be a copy of
+   * the passed-in Intent, with the component name set to the
+   * matching activity, so a call to startActivity() for this
+   * Intent is guaranteed to go to this specific activity.
+   *
+   * @param ctxt any Context will do; the value is not retained
+   * @param toValidate the Intent that you intend to use with
+   *                   startActivity()
+   * @param sigHashes the signature hashes of the app that you expect
+   *                to handle this activity
+   * @param failIfHack true if you want a SecurityException if
+   *                   a matching activity is found but it has
+   *                   the wrong signature hash, false otherwise
+   * @return null if there is no matching activity with the correct
+   * hash, or a copy of the toValidate parameter with the full component
+   * name of the target activity added to the Intent
+   */
+  public static Intent validateActivityIntent(Context ctxt,
+                                              Intent toValidate,
+                                              List<String> sigHashes,
+                                              boolean failIfHack) {
+    PackageManager pm=ctxt.getPackageManager();
+    Intent result=null;
+    List<ResolveInfo> activities=
+      pm.queryIntentActivities(toValidate, 0);
+
+    if (activities!=null) {
+      for (ResolveInfo info : activities) {
+        try {
+          if (sigHashes.contains(getSignatureHash(ctxt,
+            info.activityInfo.packageName))) {
+            ComponentName cn=
+              new ComponentName(info.activityInfo.packageName,
+                info.activityInfo.name);
+
+            result=new Intent(toValidate).setComponent(cn);
+            break;
+          }
+          else if (failIfHack) {
+            throw new SecurityException(
+              "Package has signature hash mismatch: "+
+                info.activityInfo.packageName);
+          }
+        }
+        catch (NoSuchAlgorithmException e) {
+          Log.w("SignatureUtils",
+            "Exception when computing signature hash", e);
+        }
+        catch (NameNotFoundException e) {
+          Log.w("SignatureUtils",
+            "Exception when computing signature hash", e);
+        }
+      }
+    }
+
+    return(result);
+  }
+
+  /**
+   * Confirms that the service for a given Intent has the
+   * desired signature hash.
+   *
+   * If you know the package name of the service, call
+   * setPackage() on the Intent before passing into this method.
+   * That will validate whether the package is installed and whether
+   * it has the proper signature hash. You can distinguish between
+   * these cases by passing true for the failIfHack parameter.
+   *
+   * In general, there are three possible outcomes of calling
+   * this method:
+   *
+   * 1. You get a SecurityException, because failIfHack is true,
+   * and we found some service whose app does not match the
+   * desired hash. The user may have installed a repackaged
+   * version of this app that is signed by the wrong key.
+   *
+   * 2. You get null. If failIfHack is true, this means that no
+   * service was found that matches the Intent. If failIfHack
+   * is false, this means that no service was found that matches
+   * the Intent and has a valid matching signature.
+   *
+   * 3. You get an Intent. This means we found a matching service
+   * that has a matching signature. The Intent will be a copy of
+   * the passed-in Intent, with the component name set to the
+   * matching service, so a call to startService() or
+   * bindService() for this Intent is guaranteed to go to this
+   * specific service.
+   *
+   * @param ctxt any Context will do; the value is not retained
+   * @param toValidate the Intent that you intend to use with
+   *                   startService() or bindService()
+   * @param sigHash the signature hash of the app that you expect
+   *                to handle this service
+   * @param failIfHack true if you want a SecurityException if
+   *                   a matching service is found but it has
+   *                   the wrong signature hash, false otherwise
+   * @return null if there is no matching service with the correct
+   * hash, or a copy of the toValidate parameter with the full component
+   * name of the target service added to the Intent
+   */
+  public static Intent validateServiceIntent(Context ctxt,
+                                             Intent toValidate,
+                                             String sigHash,
+                                             boolean failIfHack) {
+    ArrayList<String> sigHashes=new ArrayList<String>();
+
+    sigHashes.add(sigHash);
+
+    return(validateServiceIntent(ctxt, toValidate, sigHashes,
+      failIfHack));
+  }
+
+  /**
+   * Confirms that the service for a given Intent has the
+   * desired signature hash.
+   *
+   * If you know the package name of the service, call
+   * setPackage() on the Intent before passing into this method.
+   * That will validate whether the package is installed and whether
+   * it has the proper signature hash. You can distinguish between
+   * these cases by passing true for the failIfHack parameter.
+   *
+   * In general, there are three possible outcomes of calling
+   * this method:
+   *
+   * 1. You get a SecurityException, because failIfHack is true,
+   * and we found some service whose app does not match the
+   * desired hash. The user may have installed a repackaged
+   * version of this app that is signed by the wrong key.
+   *
+   * 2. You get null. If failIfHack is true, this means that no
+   * service was found that matches the Intent. If failIfHack
+   * is false, this means that no service was found that matches
+   * the Intent and has a valid matching signature.
+   *
+   * 3. You get an Intent. This means we found a matching service
+   * that has a matching signature. The Intent will be a copy of
+   * the passed-in Intent, with the component name set to the
+   * matching service, so a call to startService() or
+   * bindService() for this Intent is guaranteed to go to this
+   * specific service.
+   *
+   * @param ctxt any Context will do; the value is not retained
+   * @param toValidate the Intent that you intend to use with
+   *                   startService() or bindService()
+   * @param sigHashes the signature hash of the app that you expect
+   *                to handle this service
+   * @param failIfHack true if you want a SecurityException if
+   *                   a matching service is found but it has
+   *                   the wrong signature hash, false otherwise
+   * @return null if there is no matching service with the correct
+   * hash, or a copy of the toValidate parameter with the full component
+   * name of the target service added to the Intent
+   */
+  public static Intent validateServiceIntent(Context ctxt,
+                                             Intent toValidate,
+                                             List<String> sigHashes,
+                                             boolean failIfHack) {
+    PackageManager pm=ctxt.getPackageManager();
+    Intent result=null;
+    List<ResolveInfo> services=
+      pm.queryIntentServices(toValidate, 0);
+
+    if (services!=null) {
+      for (ResolveInfo info : services) {
+        try {
+          if (sigHashes.contains(getSignatureHash(ctxt,
+            info.serviceInfo.packageName))) {
+            ComponentName cn=
+              new ComponentName(info.serviceInfo.packageName,
+                info.serviceInfo.name);
+
+            result=new Intent(toValidate).setComponent(cn);
+            break;
+          }
+          else if (failIfHack) {
+            throw new SecurityException(
+              "Package has signature hash mismatch: "+
+                info.activityInfo.packageName);
+          }
+        }
+        catch (NoSuchAlgorithmException e) {
+          Log.w("SignatureUtils",
+            "Exception when computing signature hash", e);
+        }
+        catch (NameNotFoundException e) {
+          Log.w("SignatureUtils",
+            "Exception when computing signature hash", e);
+        }
+      }
+    }
+
+    return(result);
+  }
+}

--- a/libnetcipher/src/info/guardianproject/netcipher/proxy/StatusCallback.java
+++ b/libnetcipher/src/info/guardianproject/netcipher/proxy/StatusCallback.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2016 CommonsWare, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package info.guardianproject.netcipher.proxy;
+
+import android.content.Intent;
+
+/**
+ * Callback interface used for reporting Orbot status
+ */
+public interface StatusCallback {
+  /**
+   * Called when Orbot is operational
+   *
+   * @param statusIntent an Intent containing information about
+   *                     Orbot, including proxy ports
+   */
+  void onEnabled(Intent statusIntent);
+
+  /**
+   * Called when Orbot reports that it is starting up
+   */
+  void onStarting();
+
+  /**
+   * Called when Orbot reports that it is shutting down
+   */
+  void onStopping();
+
+  /**
+   * Called when Orbot reports that it is no longer running
+   */
+  void onDisabled();
+
+  /**
+   * Called if our attempt to get a status from Orbot failed
+   * after a defined period of time. See statusTimeout() on
+   * OrbotInitializer.
+   */
+  void onStatusTimeout();
+
+  /**
+   * Called if Orbot is not yet installed. Usually, you handle
+   * this by checking the return value from init() on OrbotInitializer
+   * or calling isInstalled() on OrbotInitializer. However, if
+   * you have need for it, if a callback is registered before
+   * an init() call determines that Orbot is not installed, your
+   * callback will be called with onNotYetInstalled().
+   */
+  void onNotYetInstalled();
+}


### PR DESCRIPTION
This is a preliminary pull request to extend `OrbotHelper` to manage the broadcast-based communications between the NetCipher-enhanced app and Orbot itself. It is part of the overall initiative to get NetCipher integrated with major HTTP stacks with minimal developer effort.

This pull request bumps the library's `minSdkVersion` to 9, per a discussion on the `guardian-dev` list. If that is not desired, let me know, and we can discuss options on the list, here, in an issue, etc.

This pull request includes code to validate the signing key of Orbot and only work with Orbot installations that are signed by a recognized signing key. I am using two hashes, derived from the Play Store and F-Droid editions of Orbot. These hashes are the same SHA-256 ones that you would get from running `keytool` on the keystore. If you do not want this level of validation, I can remove this code. If you do want this validation, we should make sure that we have all necessary hashes, as I do not know if there are other official Orbots rolling around.

The code to actually validate the signatures is a copy of my `SignatureUtils` class from my CWAC-Security library. It contains additional methods that are unrelated to what `OrbotHelper` is doing. I can remove that code if desired.

There are no tests for this, as the intention is to test this code by means of testing the HTTP stack integrations that rely upon this extended `OrbotHelper`. If that is a problem, let me know.

And, of course, if there are other issues or concerns with what is proposed here, just shout.
