### PR TITLE
stop overriding default SSLSocketFactory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,9 @@ script:
   - emulator -avd test -no-skin -no-audio -no-window &
   - android-wait-for-emulator
   - adb shell input keyevent 82 &
+  # install Orbot to test against
+  - curl --silent https://guardianproject.info/fdroid/repo/Orbot-v15.1.2.apk > orbot.apk
+  - adb -e install -r orbot.apk
   # now run the tests that require a device/emulator
   - ./gradlew connectedCheck -PdisablePreDex
 

--- a/libnetcipher/src/info/guardianproject/netcipher/NetCipher.java
+++ b/libnetcipher/src/info/guardianproject/netcipher/NetCipher.java
@@ -125,6 +125,34 @@ public class NetCipher {
     }
 
     /**
+     * Get a {@link TlsOnlySocketFactory} from NetCipher.
+     *
+     * @see HttpsURLConnection#setDefaultSSLSocketFactory(SSLSocketFactory)
+     */
+    public static TlsOnlySocketFactory getTlsOnlySocketFactory() {
+        return getTlsOnlySocketFactory(false);
+    }
+
+    /**
+     * Get a {@link TlsOnlySocketFactory} from NetCipher, and specify whether
+     * it should use a more compatible, but less strong, suite of ciphers.
+     *
+     * @see HttpsURLConnection#setDefaultSSLSocketFactory(SSLSocketFactory)
+     */
+    public static TlsOnlySocketFactory getTlsOnlySocketFactory(boolean compatible) {
+        SSLContext sslcontext;
+        try {
+            sslcontext = SSLContext.getInstance("TLSv1");
+            sslcontext.init(null, null, null);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalArgumentException(e);
+        } catch (KeyManagementException e) {
+            throw new IllegalArgumentException(e);
+        }
+        return new TlsOnlySocketFactory(sslcontext.getSocketFactory(), compatible);
+    }
+
+    /**
      * Get a {@link HttpURLConnection} from a {@link URL}, and specify whether
      * it should use a more compatible, but less strong, suite of ciphers.
      *
@@ -149,17 +177,7 @@ public class NetCipher {
         }
 
         if (connection instanceof HttpsURLConnection) {
-            SSLContext sslcontext;
-            try {
-                sslcontext = SSLContext.getInstance("TLSv1");
-                sslcontext.init(null, null, null); // null means use default
-            } catch (NoSuchAlgorithmException e) {
-                throw new IllegalArgumentException(e);
-            } catch (KeyManagementException e) {
-                throw new IllegalArgumentException(e);
-            }
-            SSLSocketFactory tlsOnly = new TlsOnlySocketFactory(sslcontext.getSocketFactory(),
-                    compatible);
+            SSLSocketFactory tlsOnly = getTlsOnlySocketFactory(compatible);
             ((HttpsURLConnection) connection).setSSLSocketFactory(tlsOnly);
         }
         return connection;


### PR DESCRIPTION
If there are issues with incompatibilities with this setup, then it is difficult to reset the default `SSLSocketFactory` once it has been overridden. This changes things to just set the `SSLSocketFactory` for the specific `HttpsURLConnection` instance that is being returned.