### PR TITLE
StrongBuilder framework, plus StrongConnectionBuilder for HURL

### DIFF
--- a/libnetcipher/src/info/guardianproject/netcipher/client/StrongBuilder.java
+++ b/libnetcipher/src/info/guardianproject/netcipher/client/StrongBuilder.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2016 CommonsWare, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package info.guardianproject.netcipher.client;
+
+import android.content.Intent;
+import java.io.IOException;
+import java.security.KeyManagementException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.CertificateException;
+import javax.net.ssl.TrustManager;
+
+public interface StrongBuilder<T extends StrongBuilder, C> {
+  /**
+   * Callback to get a connection handed to you for use,
+   * already set up for NetCipher.
+   *
+   * @param <C> the type of connection created by this builder
+   */
+  interface Callback<C> {
+    /**
+     * Called when the NetCipher-enhanced connection is ready
+     * for use.
+     *
+     * @param connection the connection
+     */
+    void onConnected(C connection);
+
+    /**
+     * Called if we tried to connect through to Orbot but failed
+     * for some reason
+     *
+     * @param e the reason
+     */
+    void onConnectionException(IOException e);
+
+    /**
+     * Called if our attempt to get a status from Orbot failed
+     * after a defined period of time. See statusTimeout() on
+     * OrbotInitializer.
+     */
+    void onTimeout();
+  }
+
+  /**
+   * Call this to configure the Tor proxy from the results
+   * returned by Orbot, using the best available proxy
+   * (SOCKS if possible, else HTTP)
+   *
+   * @return the builder
+   */
+  T withBestProxy();
+
+  /**
+   * @return true if this builder supports HTTP proxies, false
+   * otherwise
+   */
+  boolean supportsHttpProxy();
+
+  /**
+   * Call this to configure the Tor proxy from the results
+   * returned by Orbot, using the HTTP proxy.
+   *
+   * @return the builder
+   */
+   T withHttpProxy();
+
+  /**
+   * @return true if this builder supports SOCKS proxies, false
+   * otherwise
+   */
+   boolean supportsSocksProxy();
+
+  /**
+   * Call this to configure the Tor proxy from the results
+   * returned by Orbot, using the SOCKS proxy.
+   *
+   * @return the builder
+   */
+  T withSocksProxy();
+
+  /**
+   * Applies your own custom TrustManagers, such as for
+   * replacing the stock keystore support with a custom
+   * keystore.
+   *
+   * @param trustManagers the TrustManagers to use
+   * @return the builder
+   */
+  T withTrustManagers(TrustManager[] trustManagers)
+    throws NoSuchAlgorithmException, KeyManagementException;
+
+  /**
+   * Call this if you want a weaker set of supported ciphers,
+   * because you are running into compatibility problems with
+   * some server due to a cipher mismatch. The better solution
+   * is to fix the server.
+   *
+   * @return the builder
+   */
+  T withWeakCiphers();
+
+  /**
+   * Builds a connection, applying the configuration already
+   * specified in the builder.
+   *
+   * @param status status Intent from OrbotInitializer
+   * @return the connection
+   * @throws IOException
+   */
+  C build(Intent status) throws IOException;
+
+  /**
+   * Asynchronous version of build(), one that uses OrbotInitializer
+   * internally to get the status.
+   *
+   * @param callback Callback to get a connection handed to you
+   *                 for use, already set up for NetCipher
+   */
+  void build(Callback<C> callback);
+}

--- a/libnetcipher/src/info/guardianproject/netcipher/client/StrongBuilderBase.java
+++ b/libnetcipher/src/info/guardianproject/netcipher/client/StrongBuilderBase.java
@@ -44,8 +44,6 @@ abstract public class
   StrongBuilderBase<T extends StrongBuilderBase, C>
   implements StrongBuilder<T, C> {
   private final static String PROXY_HOST="127.0.0.1";
-  private final static String TRUSTSTORE_TYPE="BKS";
-  private final static String TRUSTSTORE_PASSWORD="changeit";
   protected final Context ctxt;
   protected Proxy.Type proxyType;
   protected SSLContext sslContext=null;

--- a/libnetcipher/src/info/guardianproject/netcipher/client/StrongBuilderBase.java
+++ b/libnetcipher/src/info/guardianproject/netcipher/client/StrongBuilderBase.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright 2012-2016 Nathan Freitas
+ * Copyright 2015 str4d
+ * Portions Copyright (c) 2016 CommonsWare, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package info.guardianproject.netcipher.client;
+
+import android.content.Context;
+import android.content.Intent;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.security.KeyManagementException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.CertificateException;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import info.guardianproject.netcipher.proxy.OrbotHelper;
+
+/**
+ * Builds an HttpUrlConnection that connects via Tor through
+ * Orbot.
+ */
+abstract public class
+  StrongBuilderBase<T extends StrongBuilderBase, C>
+  implements StrongBuilder<T, C> {
+  private final static String PROXY_HOST="127.0.0.1";
+  private final static String TRUSTSTORE_TYPE="BKS";
+  private final static String TRUSTSTORE_PASSWORD="changeit";
+  protected final Context ctxt;
+  protected Proxy.Type proxyType;
+  protected SSLContext sslContext=null;
+  protected boolean useWeakCiphers=false;
+
+  /**
+   * Standard constructor.
+   *
+   * @param ctxt any Context will do; the StrongBuilderBase
+   *             will hold onto the Application singleton
+   */
+  public StrongBuilderBase(Context ctxt) {
+    this.ctxt=ctxt.getApplicationContext();
+  }
+
+  /**
+   * Copy constructor.
+   *
+   * @param original builder to clone
+   */
+  public StrongBuilderBase(StrongBuilderBase original) {
+    this.ctxt=original.ctxt;
+    this.proxyType=original.proxyType;
+    this.sslContext=original.sslContext;
+    this.useWeakCiphers=original.useWeakCiphers;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public T withBestProxy() {
+    if (supportsSocksProxy()) {
+      return(withSocksProxy());
+    }
+    else {
+      return(withHttpProxy());
+    }
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public boolean supportsHttpProxy() {
+    return(true);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public T withHttpProxy() {
+    proxyType=Proxy.Type.HTTP;
+
+    return((T)this);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public boolean supportsSocksProxy() {
+    return(false);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public T withSocksProxy() {
+    proxyType=Proxy.Type.SOCKS;
+
+    return((T)this);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public T withTrustManagers(TrustManager[] trustManagers)
+    throws NoSuchAlgorithmException, KeyManagementException {
+
+    sslContext=SSLContext.getInstance("TLSv1");
+    sslContext.init(null, trustManagers, null);
+
+    return((T)this);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public T withWeakCiphers() {
+    useWeakCiphers=true;
+
+    return((T)this);
+  }
+
+  public SSLContext getSSLContext() {
+    return(sslContext);
+  }
+
+  public int getSocksPort(Intent status) {
+    if (status.getStringExtra(OrbotHelper.EXTRA_STATUS)
+      .equals(OrbotHelper.STATUS_ON)) {
+      return(status.getIntExtra(OrbotHelper.EXTRA_PROXY_PORT_SOCKS,
+        9050));
+    }
+
+    return(-1);
+  }
+
+  public int getHttpPort(Intent status) {
+    if (status.getStringExtra(OrbotHelper.EXTRA_STATUS)
+      .equals(OrbotHelper.STATUS_ON)) {
+      return(status.getIntExtra(OrbotHelper.EXTRA_PROXY_PORT_HTTP,
+        8118));
+    }
+
+    return(-1);
+  }
+
+  protected SSLSocketFactory buildSocketFactory() {
+    SSLSocketFactory result=
+      new TlsOnlySocketFactory(sslContext.getSocketFactory(),
+        useWeakCiphers);
+
+    return(result);
+  }
+
+  public Proxy buildProxy(Intent status) {
+    Proxy result=null;
+
+    if (status.getStringExtra(OrbotHelper.EXTRA_STATUS)
+      .equals(OrbotHelper.STATUS_ON)) {
+      if (proxyType==Proxy.Type.SOCKS) {
+        result=new Proxy(Proxy.Type.SOCKS,
+          new InetSocketAddress(PROXY_HOST, getSocksPort(status)));
+      }
+      else if (proxyType==Proxy.Type.HTTP) {
+        result=new Proxy(Proxy.Type.HTTP,
+          new InetSocketAddress(PROXY_HOST, getHttpPort(status)));
+      }
+    }
+
+    return(result);
+  }
+
+  @Override
+  public void build(final Callback<C> callback) {
+    OrbotHelper.get(ctxt).addStatusCallback(
+      new OrbotHelper.SimpleStatusCallback() {
+        @Override
+        public void onEnabled(Intent statusIntent) {
+          OrbotHelper.get(ctxt).removeStatusCallback(this);
+
+          try {
+            callback.onConnected(build(statusIntent));
+          }
+          catch (IOException e) {
+            callback.onConnectionException(e);
+          }
+        }
+
+        @Override
+        public void onNotYetInstalled() {
+          OrbotHelper.get(ctxt).removeStatusCallback(this);
+          callback.onTimeout();
+        }
+
+        @Override
+        public void onStatusTimeout() {
+          OrbotHelper.get(ctxt).removeStatusCallback(this);
+          callback.onTimeout();
+        }
+      });
+  }
+}

--- a/libnetcipher/src/info/guardianproject/netcipher/client/StrongConnectionBuilder.java
+++ b/libnetcipher/src/info/guardianproject/netcipher/client/StrongConnectionBuilder.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2016 CommonsWare, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package info.guardianproject.netcipher.client;
+
+import android.content.Context;
+import android.content.Intent;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.Proxy;
+import java.net.URL;
+import java.net.URLConnection;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLSocketFactory;
+
+/**
+ * Builds an HttpUrlConnection that connects via Tor through
+ * Orbot.
+ */
+public class StrongConnectionBuilder
+  extends StrongBuilderBase<StrongConnectionBuilder, HttpURLConnection> {
+  private URL url;
+
+  /**
+   * Creates a StrongConnectionBuilder using the strongest set
+   * of options for security. Use this if the strongest set of
+   * options is what you want; otherwise, create a
+   * builder via the constructor and configure it as you see fit.
+   *
+   * @param ctxt any Context will do
+   * @return a configured StrongConnectionBuilder
+   * @throws Exception
+   */
+  static public StrongConnectionBuilder forMaxSecurity(Context ctxt)
+    throws Exception {
+    return(new StrongConnectionBuilder(ctxt)
+      .withBestProxy());
+  }
+
+  /**
+   * Creates a builder instance.
+   *
+   * @param ctxt any Context will do; builder will hold onto
+   *             Application context
+   */
+  public StrongConnectionBuilder(Context ctxt) {
+    super(ctxt);
+  }
+
+  /**
+   * Copy constructor.
+   *
+   * @param original builder to clone
+   */
+  public StrongConnectionBuilder(StrongConnectionBuilder original) {
+    super(original);
+    this.url=original.url;
+  }
+/*
+  public boolean supportsSocksProxy() {
+    return(false);
+  }
+*/
+
+  /**
+   * Sets the URL to build a connection for.
+   *
+   * @param url the URL
+   * @return the builder
+   * @throws MalformedURLException
+   */
+  public StrongConnectionBuilder connectTo(String url)
+    throws MalformedURLException {
+    connectTo(new URL(url));
+
+    return(this);
+  }
+
+  /**
+   * Sets the URL to build a connection for.
+   *
+   * @param url the URL
+   * @return the builder
+   */
+  public StrongConnectionBuilder connectTo(URL url) {
+    this.url=url;
+
+    return(this);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public HttpURLConnection build(Intent status) throws IOException {
+    URLConnection result;
+    Proxy proxy=buildProxy(status);
+
+    if (proxy==null) {
+      result=url.openConnection();
+    }
+    else {
+      result=url.openConnection(proxy);
+    }
+
+    if (result instanceof HttpsURLConnection && sslContext!=null) {
+      SSLSocketFactory tlsOnly=buildSocketFactory();
+      HttpsURLConnection https=(HttpsURLConnection)result;
+
+      https.setSSLSocketFactory(tlsOnly);
+    }
+
+    return((HttpURLConnection)result);
+  }
+}

--- a/netciphertest/src/info/guardianproject/netcipher/StrongConnectionBuilderTest.java
+++ b/netciphertest/src/info/guardianproject/netcipher/StrongConnectionBuilderTest.java
@@ -108,7 +108,7 @@ public class StrongConnectionBuilderTest extends
     testResult=null;
     builder.build(callback);
 
-    assertTrue(responseLatch.await(30, TimeUnit.SECONDS));
+    assertTrue(responseLatch.await(120, TimeUnit.SECONDS));
 
     if (innerException!=null) {
       throw innerException;

--- a/netciphertest/src/info/guardianproject/netcipher/StrongConnectionBuilderTest.java
+++ b/netciphertest/src/info/guardianproject/netcipher/StrongConnectionBuilderTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2016 CommonsWare, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package info.guardianproject.netcipher;
+
+import android.test.AndroidTestCase;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import info.guardianproject.netcipher.client.StrongBuilder;
+import info.guardianproject.netcipher.client.StrongConnectionBuilder;
+import info.guardianproject.netcipher.proxy.OrbotHelper;
+
+public class StrongConnectionBuilderTest extends
+  AndroidTestCase {
+  private static final String TEST_URL=
+    "https://wares.commonsware.com/test.json";
+  private static final String EXPECTED="{\"Hello\": \"world\"}";
+  private static boolean initialized=false;
+  private CountDownLatch responseLatch;
+  private Exception innerException=null;
+  private String testResult=null;
+
+  public void setUp() {
+    if (!initialized) {
+      OrbotHelper.get(getContext()).init();
+      initialized=true;
+    }
+
+    responseLatch=new CountDownLatch(1);
+  }
+
+  public void testDefaultHURL() throws IOException {
+    testHURL(
+      (HttpURLConnection)new URL(TEST_URL).openConnection());
+  }
+
+  public void testStrongConnectionBuilder()
+    throws Exception {
+    StrongConnectionBuilder builder=
+      StrongConnectionBuilder.forMaxSecurity(getContext());
+
+    testStrongBuilder(builder.connectTo(TEST_URL),
+      new TestBuilderCallback<HttpURLConnection>() {
+        @Override
+        protected void loadResult(HttpURLConnection c)
+          throws Exception {
+          try {
+            testResult=slurp(c.getInputStream());
+          }
+          finally {
+            c.disconnect();
+          }
+        }
+      });
+  }
+
+  private void testHURL(HttpURLConnection c) throws IOException {
+    try {
+      String result=slurp(c.getInputStream());
+
+      assertEquals(EXPECTED, result);
+    }
+    finally {
+      c.disconnect();
+    }
+  }
+
+  // based on http://stackoverflow.com/a/309718/115145
+
+  public static String slurp(final InputStream is)
+    throws IOException {
+    final char[] buffer = new char[128];
+    final StringBuilder out = new StringBuilder();
+    final Reader in = new InputStreamReader(is, "UTF-8");
+
+    for (;;) {
+      int rsz = in.read(buffer, 0, buffer.length);
+      if (rsz < 0)
+        break;
+      out.append(buffer, 0, rsz);
+    }
+
+    return out.toString();
+  }
+
+  private void testStrongBuilder(StrongBuilder builder,
+                                 TestBuilderCallback callback)
+    throws Exception {
+    testResult=null;
+    builder.build(callback);
+
+    assertTrue(responseLatch.await(30, TimeUnit.SECONDS));
+
+    if (innerException!=null) {
+      throw innerException;
+    }
+
+    assertEquals(EXPECTED, testResult);
+  }
+
+  private abstract class TestBuilderCallback<C>
+    implements StrongBuilder.Callback<C> {
+
+    abstract protected void loadResult(C connection)
+      throws Exception;
+
+    @Override
+    public void onConnected(C connection) {
+      try {
+        loadResult(connection);
+        responseLatch.countDown();
+      }
+      catch (Exception e) {
+        innerException=e;
+        responseLatch.countDown();
+      }
+    }
+
+    @Override
+    public void onConnectionException(IOException e) {
+      innerException=e;
+      responseLatch.countDown();
+    }
+
+    @Override
+    public void onTimeout() {
+      responseLatch.countDown();
+    }
+  }
+}

--- a/netciphertest/src/info/guardianproject/netcipher/StrongConnectionBuilderTest.java
+++ b/netciphertest/src/info/guardianproject/netcipher/StrongConnectionBuilderTest.java
@@ -16,6 +16,7 @@
 
 package info.guardianproject.netcipher;
 
+import android.content.Intent;
 import android.test.AndroidTestCase;
 import java.io.IOException;
 import java.io.InputStream;
@@ -28,6 +29,7 @@ import java.util.concurrent.TimeUnit;
 import info.guardianproject.netcipher.client.StrongBuilder;
 import info.guardianproject.netcipher.client.StrongConnectionBuilder;
 import info.guardianproject.netcipher.proxy.OrbotHelper;
+import info.guardianproject.netcipher.proxy.StatusCallback;
 
 public class StrongConnectionBuilderTest extends
   AndroidTestCase {
@@ -41,7 +43,38 @@ public class StrongConnectionBuilderTest extends
 
   public void setUp() {
     if (!initialized) {
-      OrbotHelper.get(getContext()).init();
+      OrbotHelper.get(getContext()).addStatusCallback(
+        new StatusCallback() {
+          @Override
+          public void onEnabled(Intent statusIntent) {
+
+          }
+
+          @Override
+          public void onStarting() {
+
+          }
+
+          @Override
+          public void onStopping() {
+
+          }
+
+          @Override
+          public void onDisabled() {
+            throw new RuntimeException("Orbot seems disabled");
+          }
+
+          @Override
+          public void onStatusTimeout() {
+            throw new RuntimeException("Orbot status request timed out");
+          }
+
+          @Override
+          public void onNotYetInstalled() {
+            throw new RuntimeException("Orbot is not installed");
+          }
+        }).init();
       initialized=true;
     }
 


### PR DESCRIPTION
This pull request integrates the core classes for the HTTP stacks integration (notably the `StrongBuilder` interface and `StrongBuilderBase` abstract implementation). It also integrates `StrongConnectionBuilder`, which implements the integration for `HttpURLConnection`. Future pull requests will add counterparts for HttpClient, Volley, and OkHttp3.

I have been running into a problem in testing, where some Orbot installations support SOCKS and others do not. On my Nexus 5, which has had Orbot for a few months, SOCKS works fine. On my Galaxy Nexus, which has had Orbot for a bit less time and *used* to handle SOCKS fine, SOCKS does not work. Likewise, on a Nexus 4 with a fresh install of Orbot off of the Play Store, SOCKS does not work. By "does not work", I mean attempts to use the SOCKS proxy result in `java.io.IOException: Failure to connect to SOCKS server`, as if the SOCKS proxy is not running on 127.0.0.1/9050, even though the status `Intent` does not give me an alternate port to use. I do not see any settings changes that I might have made on the Galaxy Nexus installation of Orbot, and I know I have not changed any settings on the Nexus 4 install. The HTTP proxy works fine on those devices, and so Orbot itself is otherwise happy.

Is there something an Orbot user needs to do to enable SOCKS support from an out-of-the-box Orbot install? Or, any other ideas why I can't seem to connect to SOCKS on some devices?

For the moment at least, I have changed `StrongBuilderBase`, having `supportsSocksProxy()` return `false`, to route everything through the HTTP proxy, since that seems to be working across the board. Ideally, `supportsSocksProxy()` would return `true`, then have that overridden as needed (e.g., OkHttp3 does not support SOCKS).

Note that this pull request adds a new test case class for `StrongConnectionBuilder`.
