### PR TITLE
Fixing squid issues:squid S1149,S1197,S1066,S1226,S2293,S1153

### DIFF
--- a/libnetcipher/src/info/guardianproject/netcipher/client/StrongConstants.java
+++ b/libnetcipher/src/info/guardianproject/netcipher/client/StrongConstants.java
@@ -21,7 +21,7 @@ public class StrongConstants {
 	 * Ordered to prefer the stronger cipher suites as noted
 	 * http://op-co.de/blog/posts/android_ssl_downgrade/
 	 */
-	public static final String ENABLED_CIPHERS[] = {
+	public static final String[] ENABLED_CIPHERS = {
 			"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
 			"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",
 			"TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
@@ -38,7 +38,7 @@ public class StrongConstants {
 	 * Ordered to prefer the stronger/newer TLS versions as noted
 	 * http://op-co.de/blog/posts/android_ssl_downgrade/
 	 */
-	public static final String ENABLED_PROTOCOLS[] = { "TLSv1.2", "TLSv1.1",
+	public static final String[] ENABLED_PROTOCOLS = { "TLSv1.2", "TLSv1.1",
 			"TLSv1" };
 
 }

--- a/libnetcipher/src/info/guardianproject/netcipher/client/StrongSSLSocketFactory.java
+++ b/libnetcipher/src/info/guardianproject/netcipher/client/StrongSSLSocketFactory.java
@@ -83,7 +83,7 @@ public class StrongSSLSocketFactory extends
 	}
 
 	private void readSSLParameters(SSLSocket sslSocket) {
-		List<String> protocolsToEnable = new ArrayList<String>();
+		List<String> protocolsToEnable = new ArrayList<>();
 		List<String> supportedProtocols = Arrays.asList(sslSocket.getSupportedProtocols());
 		for(String enabledProtocol : StrongConstants.ENABLED_PROTOCOLS) {
 			if(supportedProtocols.contains(enabledProtocol)) {
@@ -92,7 +92,7 @@ public class StrongSSLSocketFactory extends
 		}
 		this.mProtocols = protocolsToEnable.toArray(new String[protocolsToEnable.size()]);
 
-		List<String> cipherSuitesToEnable = new ArrayList<String>();
+		List<String> cipherSuitesToEnable = new ArrayList<>();
 		List<String> supportedCipherSuites = Arrays.asList(sslSocket.getSupportedCipherSuites());
 		for(String enabledCipherSuite : StrongConstants.ENABLED_CIPHERS) {
 			if(supportedCipherSuites.contains(enabledCipherSuite)) {

--- a/libnetcipher/src/info/guardianproject/netcipher/client/TlsOnlySocketFactory.java
+++ b/libnetcipher/src/info/guardianproject/netcipher/client/TlsOnlySocketFactory.java
@@ -90,6 +90,7 @@ public class TlsOnlySocketFactory extends SSLSocketFactory {
     }
 
     private Socket makeSocketSafe(Socket socket, String host) {
+        Socket mySocket=null;
         if (socket instanceof SSLSocket) {
             TlsOnlySSLSocket tempSocket=
               new TlsOnlySSLSocket((SSLSocket) socket, compatible);
@@ -103,9 +104,9 @@ public class TlsOnlySocketFactory extends SSLSocketFactory {
                 tempSocket.setHostname(host);
             }
 
-            socket = tempSocket;
+            mySocket = tempSocket;
         }
-        return socket;
+        return mySocket;
     }
 
     @Override
@@ -147,7 +148,7 @@ public class TlsOnlySocketFactory extends SSLSocketFactory {
 
             // badly configured servers can't handle a good config
             if (compatible) {
-                ArrayList<String> protocols = new ArrayList<String>(Arrays.asList(delegate
+                ArrayList<String> protocols = new ArrayList<>(Arrays.asList(delegate
                         .getEnabledProtocols()));
                 protocols.remove("SSLv2");
                 protocols.remove("SSLv3");
@@ -157,7 +158,7 @@ public class TlsOnlySocketFactory extends SSLSocketFactory {
                  * Exclude extremely weak EXPORT ciphers. NULL ciphers should
                  * never even have been an option in TLS.
                  */
-                ArrayList<String> enabled = new ArrayList<String>(10);
+                ArrayList<String> enabled = new ArrayList<>(10);
                 Pattern exclude = Pattern.compile(".*(EXPORT|NULL).*");
                 for (String cipher : delegate.getEnabledCipherSuites()) {
                     if (!exclude.matcher(cipher).matches()) {
@@ -170,7 +171,7 @@ public class TlsOnlySocketFactory extends SSLSocketFactory {
 
             // 16-19 support v1.1 and v1.2 but only by default starting in 20+
             // https://developer.android.com/reference/javax/net/ssl/SSLSocket.html
-            ArrayList<String> protocols = new ArrayList<String>(Arrays.asList(delegate
+            ArrayList<String> protocols = new ArrayList<>(Arrays.asList(delegate
                     .getSupportedProtocols()));
             protocols.remove("SSLv2");
             protocols.remove("SSLv3");
@@ -180,7 +181,7 @@ public class TlsOnlySocketFactory extends SSLSocketFactory {
              * Exclude weak ciphers, like EXPORT, MD5, DES, and DH. NULL ciphers
              * should never even have been an option in TLS.
              */
-            ArrayList<String> enabledCiphers = new ArrayList<String>(10);
+            ArrayList<String> enabledCiphers = new ArrayList<>(10);
             Pattern exclude = Pattern.compile(".*(_DES|DH_|DSS|EXPORT|MD5|NULL|RC4).*");
             for (String cipher : delegate.getSupportedCipherSuites()) {
                 if (!exclude.matcher(cipher).matches()) {
@@ -195,6 +196,7 @@ public class TlsOnlySocketFactory extends SSLSocketFactory {
          */
         @Override
         public void setEnabledProtocols(String[] protocols) {
+            String[] myProtocols=null;
             if (protocols != null && protocols.length == 1 && "SSLv3".equals(protocols[0])) {
                 List<String> systemProtocols;
                 if (this.compatible) {
@@ -202,18 +204,19 @@ public class TlsOnlySocketFactory extends SSLSocketFactory {
                 } else {
                     systemProtocols = Arrays.asList(delegate.getSupportedProtocols());
                 }
-                List<String> enabledProtocols = new ArrayList<String>(systemProtocols);
+                List<String> enabledProtocols = new ArrayList<>(systemProtocols);
                 if (enabledProtocols.size() > 1) {
                     enabledProtocols.remove("SSLv2");
                     enabledProtocols.remove("SSLv3");
                 } else {
                     Log.w(TAG, "SSL stuck with protocol available for "
-                            + String.valueOf(enabledProtocols));
+                            + enabledProtocols);
                 }
-                protocols = enabledProtocols.toArray(new String[enabledProtocols.size()]);
+                myProtocols = enabledProtocols.toArray(new String[enabledProtocols.size()]);
             }
-            super.setEnabledProtocols(protocols);
+            super.setEnabledProtocols(myProtocols);
         }
+
     }
 
     public class DelegateSSLSocket extends SSLSocket {

--- a/libnetcipher/src/info/guardianproject/netcipher/proxy/OrbotHelper.java
+++ b/libnetcipher/src/info/guardianproject/netcipher/proxy/OrbotHelper.java
@@ -215,13 +215,12 @@ public class OrbotHelper implements ProxyHelper {
      * @return whether the start request was sent to Orbot
      */
     public static boolean requestShowOrbotStart(Activity activity) {
-        if (OrbotHelper.isOrbotInstalled(activity)) {
-            if (!OrbotHelper.isOrbotRunning(activity)) {
+        if (OrbotHelper.isOrbotInstalled(activity)&&!OrbotHelper.isOrbotRunning(activity)) {
                 Intent intent = getShowOrbotStartIntent();
                 activity.startActivityForResult(intent, START_TOR_RESULT);
                 return true;
             }
-        }
+
         return false;
     }
 

--- a/libnetcipher/src/info/guardianproject/netcipher/proxy/ProxySelector.java
+++ b/libnetcipher/src/info/guardianproject/netcipher/proxy/ProxySelector.java
@@ -33,7 +33,7 @@ public class ProxySelector extends java.net.ProxySelector {
 	{
 		super ();
 		
-		listProxies = new ArrayList<Proxy>();
+		listProxies = new ArrayList<>();
 		
 		
 	}

--- a/libnetcipher/src/info/guardianproject/netcipher/proxy/TorServiceUtils.java
+++ b/libnetcipher/src/info/guardianproject/netcipher/proxy/TorServiceUtils.java
@@ -218,7 +218,7 @@ public class TorServiceUtils {
         if (waitFor)
         {
 
-            final char buf[] = new char[10];
+            final char[] buf = new char[10];
 
             // Consume the "stdout"
             InputStreamReader reader = new InputStreamReader(proc.getInputStream());

--- a/netciphertest/src/info/guardianproject/netcipher/HttpURLConnectionTest.java
+++ b/netciphertest/src/info/guardianproject/netcipher/HttpURLConnectionTest.java
@@ -65,7 +65,7 @@ public class HttpURLConnectionTest extends InstrumentationTestCase {
         HttpURLConnection connection = NetCipher.getHttpURLConnection(new URL(HTTP_URL_STRING
                 + port));
         InputStream is = (InputStream) connection.getContent();
-        byte buffer[] = new byte[256];
+        byte[] buffer = new byte[256];
         int read = is.read(buffer);
         String msg = new String(buffer, 0, read);
         assertEquals(content, msg);

--- a/sample/src/sample/netcipher/NetCipherSampleActivity.java
+++ b/sample/src/sample/netcipher/NetCipherSampleActivity.java
@@ -173,15 +173,12 @@ public class NetCipherSampleActivity extends Activity {
 	                	mProxySocks = intent.getIntExtra(ProxyHelper.EXTRA_PROXY_PORT_SOCKS, -1);
 	          
                 }
-                else if (intent.hasExtra(ProxyHelper.EXTRA_PACKAGE_NAME))
+                else if (intent.hasExtra(ProxyHelper.EXTRA_PACKAGE_NAME)&&intent.getStringExtra(ProxyHelper.EXTRA_PACKAGE_NAME).equals(PsiphonHelper.PACKAGE_NAME))
                 {
-                
-                	if (intent.getStringExtra(ProxyHelper.EXTRA_PACKAGE_NAME).equals(PsiphonHelper.PACKAGE_NAME))
-                	{
                 		PsiphonHelper pHelper = new PsiphonHelper();
                 		pHelper.requestStart(NetCipherSampleActivity.this);
-                	}
                 }
+
 
                 httpProxyButton.setEnabled(enabled);
                 socksProxyButton.setEnabled(enabled);
@@ -264,10 +261,8 @@ public class NetCipherSampleActivity extends Activity {
 
         HttpGet httpget = new HttpGet(url);
         HttpResponse response = httpclient.execute(httpget);
-
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb=new StringBuilder();
         sb.append(response.getStatusLine()).append("\n\n");
-
         InputStream is = response.getEntity().getContent();
 
         BufferedReader br = new BufferedReader(new InputStreamReader(is));


### PR DESCRIPTION
squid: S1149  Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used
squid: S1197 Array designators "[]" should be on the type, not the variable
squid: S1066 Collapsible "if" statements should be merged
squid S1226 Method parameters, caught exceptions and foreach variables should not be reassigned
squid: 2293  The diamond operator ("<>") should be used
squid: S1153 String.valueOf() should not be appended to a String