### PR TITLE
Fixing squid: S1192 String literals should not be duplicated

### DIFF
--- a/libnetcipher/src/info/guardianproject/netcipher/client/SocksAwareClientConnOperator.java
+++ b/libnetcipher/src/info/guardianproject/netcipher/client/SocksAwareClientConnOperator.java
@@ -43,7 +43,8 @@ public class SocksAwareClientConnOperator extends DefaultClientConnectionOperato
 
     private static final int CONNECT_TIMEOUT_MILLISECONDS = 60000;
     private static final int READ_TIMEOUT_MILLISECONDS = 60000;
-
+    private static final String SOCKS="socks";
+    private static final String STRONG_HTTPS="strongHTPPS";
     private HttpHost mProxyHost;
     private String mProxyType;
     private SocksAwareProxyRoutePlanner mRoutePlanner;
@@ -67,23 +68,23 @@ public class SocksAwareClientConnOperator extends DefaultClientConnectionOperato
             final HttpContext context,
             final HttpParams params) throws IOException {
         if (mProxyHost != null) {
-            if (mProxyType != null && mProxyType.equalsIgnoreCase("socks")) {
-                Log.d("StrongHTTPS", "proxying using SOCKS");
+            if (mProxyType != null && mProxyType.equalsIgnoreCase(SOCKS)) {
+                Log.d(STRONG_HTTPS, "proxying using SOCKS");
                 openSocksConnection(mProxyHost, conn, target, local, context, params);
             } else {
-                Log.d("StrongHTTPS", "proxying with: " + mProxyType);
+                Log.d(STRONG_HTTPS, "proxying with: " + mProxyType);
                 openNonSocksConnection(conn, target, local, context, params);
             }
         } else if (mRoutePlanner != null) {
             if (mRoutePlanner.isProxy(target)) {
                 // HTTP proxy, already handled by the route planner system
-                Log.d("StrongHTTPS", "proxying using non-SOCKS");
+                Log.d(STRONG_HTTPS, "proxying using non-SOCKS");
                 openNonSocksConnection(conn, target, local, context, params);
             } else {
                 // Either SOCKS or direct
                 HttpHost proxy = mRoutePlanner.determineRequiredProxy(target, null, context);
                 if (proxy == null) {
-                    Log.d("StrongHTTPS", "not proxying");
+                    Log.d(STRONG_HTTPS, "not proxying");
                     openNonSocksConnection(conn, target, local, context, params);
                 } else if (mRoutePlanner.isSocksProxy(proxy)) {
                     Log.d("StrongHTTPS", "proxying using SOCKS");
@@ -93,7 +94,7 @@ public class SocksAwareClientConnOperator extends DefaultClientConnectionOperato
                 }
             }
         } else {
-            Log.d("StrongHTTPS", "not proxying");
+            Log.d(STRONG_HTTPS, "not proxying");
             openNonSocksConnection(conn, target, local, context, params);
         }
     }
@@ -239,7 +240,7 @@ public class SocksAwareClientConnOperator extends DefaultClientConnectionOperato
             final HttpHost target,
             final HttpContext context,
             final HttpParams params) throws IOException {
-        if (mProxyHost != null && mProxyType.equalsIgnoreCase("socks"))
+        if (mProxyHost != null && mProxyType.equalsIgnoreCase(SOCKS))
             throw new RuntimeException("operation not supported");
         else
             super.updateSecureConnection(conn, target, context, params);
@@ -247,7 +248,7 @@ public class SocksAwareClientConnOperator extends DefaultClientConnectionOperato
 
     @Override
     protected InetAddress[] resolveHostname(final String host) throws UnknownHostException {
-        if (mProxyHost != null && mProxyType.equalsIgnoreCase("socks"))
+        if (mProxyHost != null && mProxyType.equalsIgnoreCase(SOCKS))
             throw new RuntimeException("operation not supported");
         else
             return super.resolveHostname(host);

--- a/libnetcipher/src/info/guardianproject/netcipher/client/TlsOnlySocketFactory.java
+++ b/libnetcipher/src/info/guardianproject/netcipher/client/TlsOnlySocketFactory.java
@@ -55,6 +55,8 @@ import javax.net.ssl.SSLSocketFactory;
 public class TlsOnlySocketFactory extends SSLSocketFactory {
     private static final int HANDSHAKE_TIMEOUT=0;
     private static final String TAG = "TlsOnlySocketFactory";
+    private static final String SSL_V2 = "SSLv2";
+    private static final String SSL_V3 = "SSLv3";
     private final SSLSocketFactory delegate;
     private final boolean compatible;
 
@@ -149,8 +151,8 @@ public class TlsOnlySocketFactory extends SSLSocketFactory {
             if (compatible) {
                 ArrayList<String> protocols = new ArrayList<String>(Arrays.asList(delegate
                         .getEnabledProtocols()));
-                protocols.remove("SSLv2");
-                protocols.remove("SSLv3");
+                protocols.remove(SSL_V2);
+                protocols.remove(SSL_V3);
                 super.setEnabledProtocols(protocols.toArray(new String[protocols.size()]));
 
                 /*
@@ -172,8 +174,8 @@ public class TlsOnlySocketFactory extends SSLSocketFactory {
             // https://developer.android.com/reference/javax/net/ssl/SSLSocket.html
             ArrayList<String> protocols = new ArrayList<String>(Arrays.asList(delegate
                     .getSupportedProtocols()));
-            protocols.remove("SSLv2");
-            protocols.remove("SSLv3");
+            protocols.remove(SSL_V2);
+            protocols.remove(SSL_V3);
             super.setEnabledProtocols(protocols.toArray(new String[protocols.size()]));
 
             /*
@@ -195,7 +197,7 @@ public class TlsOnlySocketFactory extends SSLSocketFactory {
          */
         @Override
         public void setEnabledProtocols(String[] protocols) {
-            if (protocols != null && protocols.length == 1 && "SSLv3".equals(protocols[0])) {
+            if (protocols != null && protocols.length == 1 && SSL_V3.equals(protocols[0])) {
                 List<String> systemProtocols;
                 if (this.compatible) {
                     systemProtocols = Arrays.asList(delegate.getEnabledProtocols());
@@ -204,8 +206,8 @@ public class TlsOnlySocketFactory extends SSLSocketFactory {
                 }
                 List<String> enabledProtocols = new ArrayList<String>(systemProtocols);
                 if (enabledProtocols.size() > 1) {
-                    enabledProtocols.remove("SSLv2");
-                    enabledProtocols.remove("SSLv3");
+                    enabledProtocols.remove(SSL_V2);
+                    enabledProtocols.remove(SSL_V3);
                 } else {
                     Log.w(TAG, "SSL stuck with protocol available for "
                             + String.valueOf(enabledProtocols));

--- a/libnetcipher/src/info/guardianproject/netcipher/web/WebkitProxy.java
+++ b/libnetcipher/src/info/guardianproject/netcipher/web/WebkitProxy.java
@@ -54,6 +54,10 @@ public class WebkitProxy {
     private final static int REQUEST_CODE = 0;
 
     private final static String TAG = "OrbotHelpher";
+    private final static String HTTP_PROXY_HOST = "http.proxyHost";
+    private final static String HTTP_PROXY_PORT = "http.proxyPort";
+    private final static String HTTPS_PROXY_HOST = "https.proxyHost";
+    private final static String HTTPS_PROXY_PORT = "https.proxyPort";
 
     public static boolean setProxy(String appClass, Context ctx, WebView wView, String host, int port) throws Exception
     {
@@ -94,11 +98,11 @@ public class WebkitProxy {
     	System.setProperty("proxyHost", host);
         System.setProperty("proxyPort", port + "");
 
-        System.setProperty("http.proxyHost", host);
-        System.setProperty("http.proxyPort", port + "");
+        System.setProperty(HTTP_PROXY_HOST, host);
+        System.setProperty(HTTP_PROXY_PORT, port + "");
 
-        System.setProperty("https.proxyHost", host);
-        System.setProperty("https.proxyPort", port + "");
+        System.setProperty(HTTPS_PROXY_HOST, host);
+        System.setProperty(HTTPS_PROXY_PORT, port + "");
 
         
         System.setProperty("socks.proxyHost", host);
@@ -129,11 +133,11 @@ public class WebkitProxy {
         System.setProperty("proxyHost", "");
         System.setProperty("proxyPort", "");
 
-        System.setProperty("http.proxyHost", "");
-        System.setProperty("http.proxyPort", "");
+        System.setProperty(HTTP_PROXY_HOST, "");
+        System.setProperty(HTTP_PROXY_PORT, "");
 
-        System.setProperty("https.proxyHost", "");
-        System.setProperty("https.proxyPort", "");
+        System.setProperty(HTTPS_PROXY_HOST, "");
+        System.setProperty(HTTPS_PROXY_PORT, "");
 
 
         System.setProperty("socks.proxyHost", "");
@@ -305,10 +309,10 @@ private static Object getFieldValueSafely(Field field, Object classInstance) thr
     	
     	if (host != null)
     	{
-	        System.setProperty("http.proxyHost", host);
-	        System.setProperty("http.proxyPort", port + "");
-	        System.setProperty("https.proxyHost", host);
-	        System.setProperty("https.proxyPort", port + "");
+	        System.setProperty(HTTP_PROXY_HOST, host);
+	        System.setProperty(HTTP_PROXY_PORT, port + "");
+	        System.setProperty(HTTPS_PROXY_HOST, host);
+	        System.setProperty(HTTPS_PROXY_PORT, port + "");
     	}
         
         try {
@@ -400,10 +404,10 @@ private static Object getFieldValueSafely(Field field, Object classInstance) thr
     @SuppressWarnings("rawtypes")
     private static boolean setWebkitProxyLollipop(Context appContext, String host, int port)
     {
-        System.setProperty("http.proxyHost", host);
-        System.setProperty("http.proxyPort", port + "");
-        System.setProperty("https.proxyHost", host);
-        System.setProperty("https.proxyPort", port + "");
+        System.setProperty(HTTP_PROXY_HOST, host);
+        System.setProperty(HTTP_PROXY_PORT, port + "");
+        System.setProperty(HTTPS_PROXY_HOST, host);
+        System.setProperty(HTTPS_PROXY_PORT, port + "");
         try {
             Class applictionClass = Class.forName("android.app.Application");
             Field mLoadedApkField = applictionClass.getDeclaredField("mLoadedApk");

--- a/sample/src/sample/netcipher/NetCipherSampleActivity.java
+++ b/sample/src/sample/netcipher/NetCipherSampleActivity.java
@@ -59,6 +59,7 @@ import info.guardianproject.netcipher.proxy.PsiphonHelper;
 public class NetCipherSampleActivity extends Activity {
 
     private final static String TAG = "NetCipherSampleActivity";
+    private final static String STATUS = "status";
     private TextView txtView;
     private EditText txtUrl;
     private Button httpProxyButton;
@@ -292,7 +293,7 @@ public class NetCipherSampleActivity extends Activity {
             try
             {
                 Message msg = new Message();
-                msg.getData().putString("status", "connecting to: " + url);
+                msg.getData().putString(STATUS, "connecting to: " + url);
                 handler.sendMessage(msg);
 
                 int proxyPort = -1;
@@ -305,7 +306,7 @@ public class NetCipherSampleActivity extends Activity {
                 }
                 String resp = checkHTTP(url, mProxyType, PROXY_HOST, proxyPort);
                 msg = new Message();
-                msg.getData().putString("status", resp);
+                msg.getData().putString(STATUS, resp);
                 handler.sendMessage(msg);
             }
             catch (Exception e)
@@ -313,7 +314,7 @@ public class NetCipherSampleActivity extends Activity {
                 String err = "error connecting to: " + url + "=" + e.toString();
                 Log.e(TAG, err, e);
                 Message msg = new Message();
-                msg.getData().putString("status", err);
+                msg.getData().putString(STATUS, err);
                 handler.sendMessage(msg);
             }
         }
@@ -325,7 +326,7 @@ public class NetCipherSampleActivity extends Activity {
         @Override
         public void handleMessage(Message msg) {
 
-            String msgText = msg.getData().getString("status");
+            String msgText = msg.getData().getString(STATUS);
 
             txtView.setText(msgText);
         }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1192 - “String literals should not be duplicated”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1192
 Please let me know if you have any questions.
Fevzi Ozgul
