### PR TITLE
Fixing: squid: S1149 Synchronized classes Vector, Hashtable, Stack and String…

### DIFF
--- a/sample/src/sample/netcipher/NetCipherSampleActivity.java
+++ b/sample/src/sample/netcipher/NetCipherSampleActivity.java
@@ -265,7 +265,7 @@ public class NetCipherSampleActivity extends Activity {
         HttpGet httpget = new HttpGet(url);
         HttpResponse response = httpclient.execute(httpget);
 
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         sb.append(response.getStatusLine()).append("\n\n");
 
         InputStream is = response.getEntity().getContent();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1149 - “Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used ”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1149
 Please let me know if you have any questions.
Fevzi Ozgul