### PR TITLE
fixing squid: Array designators "[]" should be on the type, not the variable

### DIFF
--- a/libnetcipher/src/info/guardianproject/netcipher/client/StrongConstants.java
+++ b/libnetcipher/src/info/guardianproject/netcipher/client/StrongConstants.java
@@ -21,7 +21,7 @@ public class StrongConstants {
 	 * Ordered to prefer the stronger cipher suites as noted
 	 * http://op-co.de/blog/posts/android_ssl_downgrade/
 	 */
-	public static final String ENABLED_CIPHERS[] = {
+	public static final String[] ENABLED_CIPHERS= {
 			"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
 			"TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",
 			"TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
@@ -38,7 +38,7 @@ public class StrongConstants {
 	 * Ordered to prefer the stronger/newer TLS versions as noted
 	 * http://op-co.de/blog/posts/android_ssl_downgrade/
 	 */
-	public static final String ENABLED_PROTOCOLS[] = { "TLSv1.2", "TLSv1.1",
+	public static final String[] ENABLED_PROTOCOLS = { "TLSv1.2", "TLSv1.1",
 			"TLSv1" };
 
 }

--- a/libnetcipher/src/info/guardianproject/netcipher/proxy/TorServiceUtils.java
+++ b/libnetcipher/src/info/guardianproject/netcipher/proxy/TorServiceUtils.java
@@ -218,7 +218,7 @@ public class TorServiceUtils {
         if (waitFor)
         {
 
-            final char buf[] = new char[10];
+            final char[] buf = new char[10];
 
             // Consume the "stdout"
             InputStreamReader reader = new InputStreamReader(proc.getInputStream());

--- a/netciphertest/src/info/guardianproject/netcipher/HttpURLConnectionTest.java
+++ b/netciphertest/src/info/guardianproject/netcipher/HttpURLConnectionTest.java
@@ -65,7 +65,7 @@ public class HttpURLConnectionTest extends InstrumentationTestCase {
         HttpURLConnection connection = NetCipher.getHttpURLConnection(new URL(HTTP_URL_STRING
                 + port));
         InputStream is = (InputStream) connection.getContent();
-        byte buffer[] = new byte[256];
+        byte[] buffer = new byte[256];
         int read = is.read(buffer);
         String msg = new String(buffer, 0, read);
         assertEquals(content, msg);


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1197 - “Array designators ""[]"" should be on the type, not the variable”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1197
 Please let me know if you have any questions.
Fevzi Ozgul