### PR TITLE
squid: S1213 The members of an interface declaration or class should appear in a pre-defined order

### DIFF
--- a/libnetcipher/src/info/guardianproject/netcipher/NetCipher.java
+++ b/libnetcipher/src/info/guardianproject/netcipher/NetCipher.java
@@ -39,15 +39,13 @@ import info.guardianproject.netcipher.proxy.OrbotHelper;
 
 public class NetCipher {
     private static final String TAG ="NetCipher";
+    private static Proxy proxy;
+    public final static Proxy ORBOT_HTTP_PROXY = new Proxy(Proxy.Type.HTTP,
+            new InetSocketAddress("127.0.0.1", 8118));
 
     private NetCipher() {
         // this is a utility class with only static methods
     }
-
-    public final static Proxy ORBOT_HTTP_PROXY = new Proxy(Proxy.Type.HTTP,
-            new InetSocketAddress("127.0.0.1", 8118));
-
-    private static Proxy proxy;
 
     /**
      * Set the global HTTP proxy for all new {@link HttpURLConnection}s and

--- a/libnetcipher/src/info/guardianproject/netcipher/client/StrongHttpsClient.java
+++ b/libnetcipher/src/info/guardianproject/netcipher/client/StrongHttpsClient.java
@@ -44,12 +44,12 @@ public class StrongHttpsClient extends DefaultHttpClient {
     private HttpHost proxyHost;
     private String proxyType;
     private SocksAwareProxyRoutePlanner routePlanner;
-
     private StrongSSLSocketFactory sFactory;
     private SchemeRegistry mRegistry;
-
     private final static String TRUSTSTORE_TYPE = "BKS";
     private final static String TRUSTSTORE_PASSWORD = "changeit";
+    public final static String TYPE_SOCKS = "socks";
+    public final static String TYPE_HTTP = "http";
 
     public StrongHttpsClient(Context context) {
         this.context = context;
@@ -69,7 +69,21 @@ public class StrongHttpsClient extends DefaultHttpClient {
             throw new AssertionError(e);
         }
     }
+    public StrongHttpsClient(Context context, KeyStore keystore) {
+        this.context = context;
 
+        mRegistry = new SchemeRegistry();
+        mRegistry.register(
+                new Scheme(TYPE_HTTP, 80, PlainSocketFactory.getSocketFactory()));
+
+        try {
+            TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+            sFactory = new StrongSSLSocketFactory(context, trustManagerFactory.getTrustManagers(), keystore, TRUSTSTORE_PASSWORD);
+            mRegistry.register(new Scheme("https", 443, sFactory));
+        } catch (Exception e) {
+            throw new AssertionError(e);
+        }
+    }
     private KeyStore loadKeyStore () throws KeyStoreException, NoSuchAlgorithmException, CertificateException, IOException
     {
 
@@ -79,22 +93,6 @@ public class StrongHttpsClient extends DefaultHttpClient {
         trustStore.load(in, TRUSTSTORE_PASSWORD.toCharArray());
 
         return trustStore;
-    }
-
-    public StrongHttpsClient(Context context, KeyStore keystore) {
-        this.context = context;
-
-        mRegistry = new SchemeRegistry();
-        mRegistry.register(
-                new Scheme(TYPE_HTTP, 80, PlainSocketFactory.getSocketFactory()));
-
-        try {
-        	TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
-            sFactory = new StrongSSLSocketFactory(context, trustManagerFactory.getTrustManagers(), keystore, TRUSTSTORE_PASSWORD);
-            mRegistry.register(new Scheme("https", 443, sFactory));
-        } catch (Exception e) {
-            throw new AssertionError(e);
-        }
     }
 
     @Override
@@ -158,7 +156,6 @@ public class StrongHttpsClient extends DefaultHttpClient {
         sFactory.setEnableStongerDefaultSSLCipherSuite(false);
     }
 
-    public final static String TYPE_SOCKS = "socks";
-    public final static String TYPE_HTTP = "http";
+
 
 }

--- a/libnetcipher/src/info/guardianproject/netcipher/proxy/ProxyHelper.java
+++ b/libnetcipher/src/info/guardianproject/netcipher/proxy/ProxyHelper.java
@@ -21,12 +21,7 @@ import android.content.Intent;
 
 public interface ProxyHelper {
 
-	public boolean isInstalled (Context context);
-	public void requestStatus (Context context);
-	public boolean requestStart (Context context);
-	public Intent getInstallIntent (Context context);
-	public Intent getStartIntent (Context context);
-	public String getName ();
+
 
     public final static String FDROID_PACKAGE_NAME = "org.fdroid.fdroid";
     public final static String PLAY_PACKAGE_NAME = "com.android.vending";
@@ -70,5 +65,12 @@ public interface ProxyHelper {
      * apps. Fallback to the old Intent that brings up Orbot.
      */
     public final static String STATUS_STARTS_DISABLED = "STARTS_DISABLED";
+
+    public boolean isInstalled (Context context);
+    public void requestStatus (Context context);
+    public boolean requestStart (Context context);
+    public Intent getInstallIntent (Context context);
+    public Intent getStartIntent (Context context);
+    public String getName ();
 }
 


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1213 - “The members of an interface declaration or class should appear in a pre-defined order”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1213
 Please let me know if you have any questions.
Fevzi Ozgul