### PR TITLE
squid: S2160 Subclasses that add fields should override "equals"

### DIFF
--- a/libnetcipher/src/info/guardianproject/netcipher/client/TlsOnlySocketFactory.java
+++ b/libnetcipher/src/info/guardianproject/netcipher/client/TlsOnlySocketFactory.java
@@ -214,6 +214,14 @@ public class TlsOnlySocketFactory extends SSLSocketFactory {
             }
             super.setEnabledProtocols(protocols);
         }
+        public boolean equals(Object obj) {
+            if (!super.equals(obj)) {
+                return false;
+            }
+            TlsOnlySSLSocket myObj=(TlsOnlySSLSocket)obj;
+            if(this.compatible==myObj.compatible){return true;}
+            return false;
+        }
     }
 
     public class DelegateSSLSocket extends SSLSocket {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S2160 - “Subclasses that add fields should override ""equals""”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S2160
 Please let me know if you have any questions.
Fevzi Ozgul