### PR TITLE
Fixing squid: RedundantThrowsDeclarationCheck

### DIFF
--- a/libnetcipher/src/info/guardianproject/netcipher/client/StrongSSLSocketFactory.java
+++ b/libnetcipher/src/info/guardianproject/netcipher/client/StrongSSLSocketFactory.java
@@ -124,7 +124,7 @@ public class StrongSSLSocketFactory extends
 
 	@Override
 	public Socket createSocket(Socket socket, String host, int port,
-			boolean autoClose) throws IOException, UnknownHostException {
+			boolean autoClose) throws IOException {
 
 		Socket newSocket = mFactory.createSocket(socket, host, port, autoClose);
 
@@ -154,7 +154,7 @@ public class StrongSSLSocketFactory extends
 	}
 
 	@Override
-	public boolean isSecure(Socket sock) throws IllegalArgumentException {
+	public boolean isSecure(Socket sock)  {
 		return (sock instanceof SSLSocket);
 	}
 
@@ -194,7 +194,7 @@ public class StrongSSLSocketFactory extends
 
 	@Override
 	public Socket createLayeredSocket(Socket arg0, String arg1, int arg2,
-			boolean arg3) throws IOException, UnknownHostException {
+			boolean arg3) throws IOException {
 		return ((LayeredSchemeSocketFactory) mFactory).createLayeredSocket(
 				arg0, arg1, arg2, arg3);
 	}

--- a/libnetcipher/src/info/guardianproject/netcipher/web/WebkitProxy.java
+++ b/libnetcipher/src/info/guardianproject/netcipher/web/WebkitProxy.java
@@ -238,7 +238,7 @@ private static boolean setProxyUpToHC(WebView webview, String host, int port) {
 }
 
 
-private static Object getFieldValueSafely(Field field, Object classInstance) throws IllegalArgumentException, IllegalAccessException {
+private static Object getFieldValueSafely(Field field, Object classInstance) throws  IllegalAccessException {
     boolean oldAccessibleValue = field.isAccessible();
     field.setAccessible(true);
     Object result = field.get(classInstance);
@@ -738,8 +738,7 @@ private static Object getFieldValueSafely(Field field, Object classInstance) thr
     }
 
     private static Object getDeclaredField(Object obj, String name)
-            throws SecurityException, NoSuchFieldException,
-            IllegalArgumentException, IllegalAccessException {
+            throws  NoSuchFieldException,IllegalAccessException {
         Field f = obj.getClass().getDeclaredField(name);
         f.setAccessible(true);
         Object out = f.get(obj);
@@ -749,8 +748,7 @@ private static Object getFieldValueSafely(Field field, Object classInstance) thr
     }
 
     private static void setDeclaredField(Object obj, String name, Object value)
-            throws SecurityException, NoSuchFieldException,
-            IllegalArgumentException, IllegalAccessException {
+            throws  NoSuchFieldException,IllegalAccessException {
         Field f = obj.getClass().getDeclaredField(name);
         f.setAccessible(true);
         f.set(obj, value);

--- a/netciphertest/src/info/guardianproject/netcipher/HttpURLConnectionTest.java
+++ b/netciphertest/src/info/guardianproject/netcipher/HttpURLConnectionTest.java
@@ -40,7 +40,7 @@ public class HttpURLConnectionTest extends InstrumentationTestCase {
 
     private static final String HTTP_URL_STRING = "http://127.0.0.1:";
 
-    public void testConnectHttp() throws MalformedURLException, IOException {
+    public void testConnectHttp() throws  IOException {
         // include trailing \n in test string, otherwise it gets added anyhow
         final String content = "content!";
         final String httpResponse = "HTTP/1.1 200 OK\nContent-Type: text/plain\n\n" + content;
@@ -101,7 +101,7 @@ public class HttpURLConnectionTest extends InstrumentationTestCase {
     }
 
     public void testStandardHttpURLConnection()
-            throws MalformedURLException, IOException, KeyManagementException, NoSuchAlgorithmException {
+            throws  IOException, KeyManagementException, NoSuchAlgorithmException {
         String[] hosts = {
                 "yahoo.com",
                 "www.yandex.ru",
@@ -135,7 +135,7 @@ public class HttpURLConnectionTest extends InstrumentationTestCase {
     }
 
     public void testConnectHttps()
-            throws MalformedURLException, IOException, KeyManagementException {
+            throws  IOException, KeyManagementException {
         String[] hosts = {
                 "yahoo.com",
                 "www.yandex.ru",
@@ -165,7 +165,7 @@ public class HttpURLConnectionTest extends InstrumentationTestCase {
     }
 
     public void testConnectOutdatedHttps()
-            throws MalformedURLException, IOException, KeyManagementException, InterruptedException {
+            throws  IOException, KeyManagementException, InterruptedException {
         String[] hosts = {
                 // these are here to make sure it works with good servers too
                 "yahoo.com",
@@ -194,7 +194,7 @@ public class HttpURLConnectionTest extends InstrumentationTestCase {
     }
 
     public void testConnectBadSslCom()
-            throws MalformedURLException, IOException, KeyManagementException, InterruptedException {
+            throws  IOException, KeyManagementException, InterruptedException {
         String[] hosts = {
                 "wrong.host.badssl.com",
         };


### PR DESCRIPTION
This pull request is focused on resolving occurrences of SonarQube  rule 
 RedundantThrowsDeclarationCheck  - “ Throws declarations should not be superfluous"
 You can find more information about the issue here: 
https://dev.eclipse.org/sonar/coding_rules#rule_key=squid:RedundantThrowsDeclarationCheck
 Please let me know if you have any questions.
Fevzi Ozgul
