### PR TITLE
Fixing squid: S1148 Throwable.printStackTrace(...) should not be called

### DIFF
--- a/libnetcipher/src/info/guardianproject/netcipher/proxy/PsiphonHelper.java
+++ b/libnetcipher/src/info/guardianproject/netcipher/proxy/PsiphonHelper.java
@@ -19,6 +19,8 @@ import java.net.ConnectException;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import android.content.ComponentName;
 import android.content.Context;
@@ -29,8 +31,8 @@ import android.net.Uri;
 import android.text.TextUtils;
 
 public class PsiphonHelper implements ProxyHelper {
-
-    public final static String PACKAGE_NAME = "com.psiphon3";
+    private static final Logger LOGGER= Logger.getLogger(PsiphonHelper.class.getName());
+	public final static String PACKAGE_NAME = "com.psiphon3";
     public final static String COMPONENT_NAME = "com.psiphon3.StatusActivity";
     
     
@@ -158,12 +160,12 @@ public class PsiphonHelper implements ProxyHelper {
         } 
 
         catch(ConnectException ce){
-            ce.printStackTrace();
+			LOGGER.log(Level.INFO,ce.getMessage());
             return false;
         }
 
         catch (Exception ex) {
-            ex.printStackTrace();
+            LOGGER.log(Level.INFO,ex.getMessage());
             return false;
         }
     }

--- a/libnetcipher/src/info/guardianproject/netcipher/web/WebkitProxy.java
+++ b/libnetcipher/src/info/guardianproject/netcipher/web/WebkitProxy.java
@@ -27,6 +27,8 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.InetSocketAddress;
 import java.net.Socket;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import org.apache.http.HttpHost;
 
@@ -46,7 +48,6 @@ import android.util.Log;
 import android.webkit.WebView;
 
 public class WebkitProxy {
-
     private final static String DEFAULT_HOST = "localhost";//"127.0.0.1";
     private final static int DEFAULT_PORT = 8118;
     private final static int DEFAULT_SOCKS_PORT = 9050;

--- a/netciphertest/src/info/guardianproject/netcipher/HttpURLConnectionTest.java
+++ b/netciphertest/src/info/guardianproject/netcipher/HttpURLConnectionTest.java
@@ -30,6 +30,8 @@ import java.net.Socket;
 import java.net.URL;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
@@ -39,7 +41,7 @@ import info.guardianproject.netcipher.client.TlsOnlySocketFactory;
 public class HttpURLConnectionTest extends InstrumentationTestCase {
 
     private static final String HTTP_URL_STRING = "http://127.0.0.1:";
-
+    private static final Logger LOGGER= Logger.getLogger(HttpURLConnectionTest.class.getName());
     public void testConnectHttp() throws MalformedURLException, IOException {
         // include trailing \n in test string, otherwise it gets added anyhow
         final String content = "content!";
@@ -57,7 +59,7 @@ public class HttpURLConnectionTest extends InstrumentationTestCase {
                     os.close();
                     serverSocket.close();
                 } catch (IOException e) {
-                    e.printStackTrace();
+                    LOGGER.log(Level.INFO,e.getMessage());
                     fail();
                 }
             }
@@ -83,6 +85,7 @@ public class HttpURLConnectionTest extends InstrumentationTestCase {
             fail();
         } catch (IOException e) {
             // this should not connect
+            LOGGER.log(Level.INFO,e.getMessage());
         }
     }
 
@@ -97,6 +100,7 @@ public class HttpURLConnectionTest extends InstrumentationTestCase {
             fail();
         } catch (IOException e) {
             // this should not connect
+            LOGGER.log(Level.INFO,e.getMessage());
         }
     }
 
@@ -213,6 +217,7 @@ public class HttpURLConnectionTest extends InstrumentationTestCase {
             } catch (IOException e) {
                 e.printStackTrace();
                 // success! these should fail!
+                LOGGER.log(Level.INFO,e.getMessage());
             } finally {
                 connection.disconnect();
             }


### PR DESCRIPTION
 This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1148 - “Throwable.printStackTrace(...) should not be called”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1148
 Please let me know if you have any questions.
Fevzi Ozgul