### PR TITLE
travis-ci: also run tests in android-10 emulator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,8 @@ script:
   - adb shell input keyevent 82 &
   # now run the tests that require a device/emulator
   - ./gradlew connectedCheck -PdisablePreDex
+  - echo "get the full logcat here:";
+  - adb -e logcat -d | curl --silent -F 'clbin=<-' https://clbin.com;
 
   # kill any running emulator
   - ps -ef | grep '[e]mulator'
@@ -81,3 +83,6 @@ script:
 
 after_failure:
   - find * -name lint-results.xml | xargs cat
+  - adb -e logcat -d '*:E';
+  - echo "get the full logcat here:";
+  - adb -e logcat -d | curl --silent -F 'clbin=<-' https://clbin.com;

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ language: android
 
 env:
   global:
-    - EMULATOR_API_LEVEL=21
+    - FIRST_EMULATOR_API_LEVEL=10
+    - SECOND_EMULATOR_API_LEVEL=21
     # switch glibc to a memory conserving mode
     - MALLOC_ARENA_MAX=2
     # wait 5 minutes for adb to connect to emulator. Travis-ci cancels a
@@ -35,8 +36,10 @@ android:
     - build-tools-23.0.2
     - extra-android-m2repository
     - android-22
-    - android-$EMULATOR_API_LEVEL
-    - sys-img-armeabi-v7a-android-$EMULATOR_API_LEVEL
+    - android-$FIRST_EMULATOR_API_LEVEL
+    - sys-img-armeabi-v7a-android-$FIRST_EMULATOR_API_LEVEL
+    - android-$SECOND_EMULATOR_API_LEVEL
+    - sys-img-armeabi-v7a-android-$SECOND_EMULATOR_API_LEVEL
   licenses:
     # only approve the non-Google licenses
     - 'android-sdk-preview-license-52d11cd2'
@@ -51,7 +54,19 @@ script:
   # 'assemble' everything and run all checks that do not require a device/emulator
   - ./gradlew build -PdisablePreDex
   # start the emulator after the build to conserve memory
-  - echo no | android create avd --force -n test -t android-$EMULATOR_API_LEVEL
+  - echo no | android create avd --force -n test -t android-$FIRST_EMULATOR_API_LEVEL
+  - emulator -avd test -no-skin -no-audio -no-window &
+  - android-wait-for-emulator
+  - adb shell input keyevent 82 &
+  # now run the tests that require a device/emulator
+  - ./gradlew connectedCheck -PdisablePreDex
+
+  # kill any running emulator
+  - ps -ef | grep '[e]mulator'
+  - kill `ps -ef | grep '[e]mulator' | awk {'print$2'}`
+
+  # now run the second emulator
+  - echo no | android create avd --force -n test -t android-$SECOND_EMULATOR_API_LEVEL
   - emulator -avd test -no-skin -no-audio -no-window &
   - android-wait-for-emulator
   - adb shell input keyevent 82 &

--- a/libnetcipher/build.gradle
+++ b/libnetcipher/build.gradle
@@ -1,4 +1,3 @@
-
 apply plugin: 'com.android.library'
 
 dependencies {
@@ -11,7 +10,7 @@ dependencies {
 }
 
 android {
-	compileSdkVersion 22
+    compileSdkVersion 22
     buildToolsVersion '23.0.2'
 
     sourceSets {
@@ -40,7 +39,20 @@ android {
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 
-	lintOptions {
-		abortOnError false
-	}
+    lintOptions {
+        abortOnError false
+    }
+
+    testOptions {
+        unitTests {
+            // prevent tests on JVM from dying on android.util.Log calls
+            returnDefaultValues = true
+            all {
+                testLogging {
+                    events "skipped", "failed", "standardOut", "standardError"
+                    showStandardStreams = true
+                }
+            }
+        }
+    }
 }

--- a/libnetcipher/src/info/guardianproject/netcipher/NetCipher.java
+++ b/libnetcipher/src/info/guardianproject/netcipher/NetCipher.java
@@ -18,6 +18,7 @@
 package info.guardianproject.netcipher;
 
 import android.net.Uri;
+import android.os.Build;
 import android.text.TextUtils;
 import android.util.Log;
 
@@ -177,8 +178,12 @@ public class NetCipher {
         }
 
         if (connection instanceof HttpsURLConnection) {
+            HttpsURLConnection httpsConnection = ((HttpsURLConnection) connection);
             SSLSocketFactory tlsOnly = getTlsOnlySocketFactory(compatible);
-            ((HttpsURLConnection) connection).setSSLSocketFactory(tlsOnly);
+            httpsConnection.setSSLSocketFactory(tlsOnly);
+            if (Build.VERSION.SDK_INT < 16) {
+                httpsConnection.setHostnameVerifier(org.apache.http.conn.ssl.SSLSocketFactory.STRICT_HOSTNAME_VERIFIER);
+            }
         }
         return connection;
     }

--- a/netciphertest/src/info/guardianproject/netcipher/HttpURLConnectionTest.java
+++ b/netciphertest/src/info/guardianproject/netcipher/HttpURLConnectionTest.java
@@ -138,14 +138,14 @@ public class HttpURLConnectionTest {
                 "yahoo.com",
                 "www.yandex.ru",
                 "openstreetmap.org",
-                "goo.gl",
+                "f-droid.org",
+                "web.wechat.com",
                 "mirrors.kernel.org",
                 "www.google.com",
                 "glympse.com",
                 // uses SNI
                 "firstlook.org",
                 "guardianproject.info",
-                "microg.org",
         };
         prefetchDns(hosts);
         // reset the default SSLSocketFactory, since it is global
@@ -175,14 +175,14 @@ public class HttpURLConnectionTest {
                 "yahoo.com",
                 "www.yandex.ru",
                 "openstreetmap.org",
-                "goo.gl",
+                "f-droid.org",
+                "web.wechat.com",
                 "mirrors.kernel.org",
                 "www.google.com",
                 "glympse.com",
                 // uses SNI
                 "firstlook.org",
                 "guardianproject.info",
-                "microg.org",
         };
         prefetchDns(hosts);
         for (String host : hosts) {
@@ -209,12 +209,12 @@ public class HttpURLConnectionTest {
                 "yahoo.com",
                 "www.yandex.ru",
                 "openstreetmap.org",
-                "goo.gl",
+                "f-droid.org",
+                "web.wechat.com",
                 "www.google.com",
                 // uses SNI
                 "firstlook.org",
                 "guardianproject.info",
-                "microg.org",
         };
         prefetchDns(hosts);
         for (String host : hosts) {
@@ -251,7 +251,7 @@ public class HttpURLConnectionTest {
             try {
                 connection.getContent();
                 System.out.println("This should not have connected, it has BAD SSL!");
-                assertTrue(false);
+                fail();
             } catch (IOException e) {
                 e.printStackTrace();
                 // success! these should fail!

--- a/netciphertest/src/info/guardianproject/netcipher/HttpURLConnectionTest.java
+++ b/netciphertest/src/info/guardianproject/netcipher/HttpURLConnectionTest.java
@@ -238,6 +238,9 @@ public class HttpURLConnectionTest {
             throws MalformedURLException, IOException, KeyManagementException, InterruptedException {
         String[] hosts = {
                 "wrong.host.badssl.com",
+                "self-signed.badssl.com",
+                "expired.badssl.com",
+                "rc4.badssl.com",
         };
         prefetchDns(hosts);
         for (String host : hosts) {

--- a/netciphertest/src/info/guardianproject/netcipher/HttpURLConnectionTest.java
+++ b/netciphertest/src/info/guardianproject/netcipher/HttpURLConnectionTest.java
@@ -164,6 +164,7 @@ public class HttpURLConnectionTest {
             assertEquals(200, connection.getResponseCode());
             assertEquals("text/html", connection.getContentType().split(";")[0]);
             System.out.println(host + " " + connection.getCipherSuite());
+            assertTrue(connection.getCipherSuite().startsWith("TLS"));
             connection.disconnect();
         }
     }
@@ -197,6 +198,7 @@ public class HttpURLConnectionTest {
             assertEquals(200, connection.getResponseCode());
             assertEquals("text/html", connection.getContentType().split(";")[0]);
             System.out.println(host + " " + connection.getCipherSuite());
+            assertTrue(connection.getCipherSuite().startsWith("TLS"));
             connection.disconnect();
         }
     }
@@ -229,6 +231,7 @@ public class HttpURLConnectionTest {
             assertEquals(200, connection.getResponseCode());
             assertEquals("text/html", connection.getContentType().split(";")[0]);
             System.out.println(host + " " + connection.getCipherSuite());
+            assertTrue(connection.getCipherSuite().startsWith("TLS"));
             connection.disconnect();
         }
     }


### PR DESCRIPTION
Since a big part of netcipher is improving HTTPS on old devices, it should be tested on android-10 to make sure it is actually doing that.  Maybe this is a little crazy to try to actually get reliable builds running on two emulators, not just one.  Wish me luck ;)