### PR TITLE
Add Tor Connection Validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,10 @@ HTTP client API
 - `withWeakCiphers()`, if you are running into compatibility issues
 with the stock selection of supported ciphers
 
+- `withTorValidation()`, if you want to confirm that not only we
+use Orbot, but that the communications via Orbot appear to be
+happening over Tor itself
+
 Of these, `withTrustManagers()` is the most likely one to be used,
 and then only if you are implementing special SSL handling (e.g.,
 certificate pinning).
@@ -157,7 +161,7 @@ of the four HTTP client APIs you are using:
 |Volley             |`StrongVolleyQueueBuilder`    |`StrongBuilder.Callback<RequestQueue>`     |
 |Apache HttpClient  |`StrongHttpClientBuilder`     |`StrongBuilder.Callback<HttpClient>`       |
 
-Your `Callback` needs to implement three methods.
+Your `Callback` needs to implement four methods.
 
 The big one is `void onConnected(C client)`, where you are handed an instance
 of your designated HTTP API connection (e.g., an `OkHttpClient` for OkHttp3).
@@ -175,9 +179,14 @@ crash reporting server, etc.
 - `void onTimeout()`, which is called if we were unable to talk to Orbot
 within 30 seconds
 
+- `void onInvalid()`, which is called if you requested that we validate
+the Tor connection and that test failed
+
 Note that `build()` itself may throw an `Exception` as well, which you will
 need to address. Otherwise, `build()` is asynchronous; you will find out
-the results via your `Callback`.
+the results via your `Callback`. Note that the `Callback` methods may be
+invoked on any thread &mdash; do not assume that the methods will be
+called on any particular thread.
 
 For example, assuming that `this` implements
 `StrongBuilder.Callback<OkHttpClient>`, you could have code like:

--- a/libnetcipher-httpclient/androidTest/src/info/guardianproject/netcipher/StrongHttpClientBuilderTest.java
+++ b/libnetcipher-httpclient/androidTest/src/info/guardianproject/netcipher/StrongHttpClientBuilderTest.java
@@ -118,7 +118,32 @@ public class StrongHttpClientBuilderTest extends
 
     if (isOrbotInstalled.get()) {
       StrongHttpClientBuilder builder=
-        StrongHttpClientBuilder.forMaxSecurity(getContext());
+        StrongHttpClientBuilder
+          .forMaxSecurity(getContext());
+
+      testStrongBuilder(builder,
+        new TestBuilderCallback<HttpClient>() {
+          @Override
+          protected void loadResult(HttpClient client)
+            throws Exception {
+            HttpGet get=new HttpGet(TEST_URL);
+
+            testResult=client.execute(get, new BasicResponseHandler());
+          }
+        });
+    }
+  }
+
+  public void testValidatedBuilder()
+    throws Exception {
+    assertTrue("we were not initialized", initialized.get());
+    assertNotNull("we did not get an Orbot status", isOrbotInstalled);
+
+    if (isOrbotInstalled.get()) {
+      StrongHttpClientBuilder builder=
+        StrongHttpClientBuilder
+          .forMaxSecurity(getContext())
+          .withTorValidation();
 
       testStrongBuilder(builder,
         new TestBuilderCallback<HttpClient>() {
@@ -192,6 +217,11 @@ public class StrongHttpClientBuilderTest extends
 
     @Override
     public void onTimeout() {
+      responseLatch.countDown();
+    }
+
+    @Override
+    public void onInvalid() {
       responseLatch.countDown();
     }
   }

--- a/libnetcipher-okhttp3/src/info/guardianproject/netcipher/client/StrongOkHttpClientBuilder.java
+++ b/libnetcipher-okhttp3/src/info/guardianproject/netcipher/client/StrongOkHttpClientBuilder.java
@@ -22,6 +22,7 @@ import android.content.Context;
 import android.content.Intent;
 import javax.net.ssl.SSLSocketFactory;
 import okhttp3.OkHttpClient;
+import okhttp3.Request;
 
 /**
  * Creates an OkHttpClient using NetCipher configuration. Use
@@ -102,5 +103,13 @@ public class StrongOkHttpClientBuilder extends
 
     return(builder
       .proxy(buildProxy(status)));
+  }
+
+  @Override
+  protected String get(Intent status, OkHttpClient connection,
+                       String url) throws Exception {
+    Request request=new Request.Builder().url(TOR_CHECK_URL).build();
+
+    return(connection.newCall(request).execute().body().string());
   }
 }

--- a/libnetcipher-volley/androidTest/src/info/guardianproject/netcipher/StrongVolleyQueueBuilderTest.java
+++ b/libnetcipher-volley/androidTest/src/info/guardianproject/netcipher/StrongVolleyQueueBuilderTest.java
@@ -115,7 +115,9 @@ public class StrongVolleyQueueBuilderTest extends
 
     if (isOrbotInstalled.get()) {
       StrongVolleyQueueBuilder builder=
-        StrongVolleyQueueBuilder.forMaxSecurity(getContext());
+        StrongVolleyQueueBuilder
+          .forMaxSecurity(getContext())
+          .withTorValidation();
 
       final StringRequest stringRequest=
         new StringRequest(StringRequest.Method.GET, TEST_URL,
@@ -148,6 +150,11 @@ public class StrongVolleyQueueBuilderTest extends
 
         @Override
         public void onTimeout() {
+          responseLatch.countDown();
+        }
+
+        @Override
+        public void onInvalid() {
           responseLatch.countDown();
         }
       });

--- a/libnetcipher/src/info/guardianproject/netcipher/client/StrongBuilder.java
+++ b/libnetcipher/src/info/guardianproject/netcipher/client/StrongBuilder.java
@@ -56,6 +56,13 @@ public interface StrongBuilder<T extends StrongBuilder, C> {
      * OrbotInitializer.
      */
     void onTimeout();
+
+    /**
+     * Called if you requested validation that we are connecting
+     * through Tor, and while we were able to connect to Orbot, that
+     * validation failed.
+     */
+    void onInvalid();
   }
 
   /**
@@ -140,7 +147,10 @@ public interface StrongBuilder<T extends StrongBuilder, C> {
 
   /**
    * Asynchronous version of build(), one that uses OrbotInitializer
-   * internally to get the status.
+   * internally to get the status and checks the validity of the Tor
+   * connection (if requested). Note that your callback methods may
+   * be invoked on any thread; do not assume that they will be called
+   * on any particular thread.
    *
    * @param callback Callback to get a connection handed to you
    *                 for use, already set up for NetCipher

--- a/libnetcipher/src/info/guardianproject/netcipher/client/StrongBuilder.java
+++ b/libnetcipher/src/info/guardianproject/netcipher/client/StrongBuilder.java
@@ -117,6 +117,18 @@ public interface StrongBuilder<T extends StrongBuilder, C> {
   T withWeakCiphers();
 
   /**
+   * Call this if you want the builder to confirm that we are
+   * communicating over Tor, by reaching out to a Tor test
+   * server and confirming our connection status. By default,
+   * this is skipped. Adding this check adds security, but it
+   * has the chance of false negatives (e.g., we cannot reach
+   * that Tor server for some reason).
+   *
+   * @return the builder
+   */
+  T withTorValidation();
+
+  /**
    * Builds a connection, applying the configuration already
    * specified in the builder.
    *

--- a/libnetcipher/src/info/guardianproject/netcipher/client/StrongBuilderBase.java
+++ b/libnetcipher/src/info/guardianproject/netcipher/client/StrongBuilderBase.java
@@ -48,6 +48,7 @@ abstract public class
   protected Proxy.Type proxyType;
   protected SSLContext sslContext=null;
   protected boolean useWeakCiphers=false;
+  protected boolean validateTor=false;
 
   /**
    * Standard constructor.
@@ -139,6 +140,16 @@ abstract public class
   @Override
   public T withWeakCiphers() {
     useWeakCiphers=true;
+
+    return((T)this);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public T withTorValidation() {
+    validateTor=true;
 
     return((T)this);
   }

--- a/netciphertest/src/info/guardianproject/netcipher/StrongConnectionBuilderTest.java
+++ b/netciphertest/src/info/guardianproject/netcipher/StrongConnectionBuilderTest.java
@@ -116,7 +116,8 @@ public class StrongConnectionBuilderTest extends
 
     if (isOrbotInstalled.get()) {
       StrongConnectionBuilder builder=
-        StrongConnectionBuilder.forMaxSecurity(getContext());
+        StrongConnectionBuilder
+          .forMaxSecurity(getContext());
 
       testStrongBuilder(builder.connectTo(TEST_URL),
         new TestBuilderCallback<HttpURLConnection>() {
@@ -124,7 +125,8 @@ public class StrongConnectionBuilderTest extends
           protected void loadResult(HttpURLConnection c)
             throws Exception {
             try {
-              testResult=slurp(c.getInputStream());
+              testResult=
+                StrongConnectionBuilder.slurp(c.getInputStream());
             }
             finally {
               c.disconnect();
@@ -134,22 +136,32 @@ public class StrongConnectionBuilderTest extends
     }
   }
 
-  // based on http://stackoverflow.com/a/309718/115145
+  public void testValidatedStrongConnectionBuilder()
+    throws Exception {
+    assertTrue("we were not initialized", initialized.get());
+    assertNotNull("we did not get an Orbot status", isOrbotInstalled);
 
-  public static String slurp(final InputStream is)
-    throws IOException {
-    final char[] buffer = new char[128];
-    final StringBuilder out = new StringBuilder();
-    final Reader in = new InputStreamReader(is, "UTF-8");
+    if (isOrbotInstalled.get()) {
+      StrongConnectionBuilder builder=
+        StrongConnectionBuilder
+          .forMaxSecurity(getContext())
+          .withTorValidation();
 
-    for (;;) {
-      int rsz = in.read(buffer, 0, buffer.length);
-      if (rsz < 0)
-        break;
-      out.append(buffer, 0, rsz);
+      testStrongBuilder(builder.connectTo(TEST_URL),
+        new TestBuilderCallback<HttpURLConnection>() {
+          @Override
+          protected void loadResult(HttpURLConnection c)
+            throws Exception {
+            try {
+              testResult=
+                StrongConnectionBuilder.slurp(c.getInputStream());
+            }
+            finally {
+              c.disconnect();
+            }
+          }
+        });
     }
-
-    return out.toString();
   }
 
   private void testStrongBuilder(StrongBuilder builder,
@@ -193,6 +205,11 @@ public class StrongConnectionBuilderTest extends
 
     @Override
     public void onTimeout() {
+      responseLatch.countDown();
+    }
+
+    @Override
+    public void onInvalid() {
       responseLatch.countDown();
     }
   }

--- a/sample-httpclient/res/values/strings.xml
+++ b/sample-httpclient/res/values/strings.xml
@@ -3,5 +3,6 @@
     <string name="app_name">NetCipher HttpClient Sample</string>
     <string name="msg_timeout">Tor not available; timed out</string>
     <string name="msg_crash">Ick! We crashed!</string>
+    <string name="msg_invalid">Hey! Our communications are not going over Tor!</string>
 
 </resources>

--- a/sample-httpclient/src/sample/netcipher/httpclient/MainActivity.java
+++ b/sample-httpclient/src/sample/netcipher/httpclient/MainActivity.java
@@ -50,6 +50,7 @@ public class MainActivity extends ListActivity implements
     try {
       StrongHttpClientBuilder
         .forMaxSecurity(this)
+        .withTorValidation()
         .build(this);
     }
     catch (Exception e) {
@@ -103,6 +104,14 @@ public class MainActivity extends ListActivity implements
   public void onTimeout() {
     Toast
       .makeText(this, R.string.msg_timeout, Toast.LENGTH_LONG)
+      .show();
+    finish();
+  }
+
+  @Override
+  public void onInvalid() {
+    Toast
+      .makeText(this, R.string.msg_invalid, Toast.LENGTH_LONG)
       .show();
     finish();
   }

--- a/sample-hurl/res/values/strings.xml
+++ b/sample-hurl/res/values/strings.xml
@@ -3,5 +3,6 @@
     <string name="app_name">NetCipher HURL Sample</string>
     <string name="msg_timeout">Tor not available; timed out</string>
     <string name="msg_crash">Ick! We crashed!</string>
+    <string name="msg_invalid">Hey! Our communications are not going over Tor!</string>
 
 </resources>

--- a/sample-hurl/src/sample/netcipher/hurl/MainActivity.java
+++ b/sample-hurl/src/sample/netcipher/hurl/MainActivity.java
@@ -50,6 +50,7 @@ public class MainActivity extends ListActivity implements
     try {
       StrongConnectionBuilder
         .forMaxSecurity(this)
+        .withTorValidation()
         .connectTo(SO_URL)
         .build(this);
     }
@@ -109,6 +110,14 @@ public class MainActivity extends ListActivity implements
   public void onTimeout() {
     Toast
       .makeText(this, R.string.msg_timeout, Toast.LENGTH_LONG)
+      .show();
+    finish();
+  }
+
+  @Override
+  public void onInvalid() {
+    Toast
+      .makeText(this, R.string.msg_invalid, Toast.LENGTH_LONG)
       .show();
     finish();
   }

--- a/sample-okhttp3/res/values/strings.xml
+++ b/sample-okhttp3/res/values/strings.xml
@@ -3,5 +3,6 @@
     <string name="app_name">NetCipher OkHttp3 Sample</string>
     <string name="msg_timeout">Tor not available; timed out</string>
     <string name="msg_crash">Ick! We crashed!</string>
+    <string name="msg_invalid">Hey! Our communications are not going over Tor!</string>
 
 </resources>

--- a/sample-okhttp3/src/sample/netcipher/okhttp3/MainActivity.java
+++ b/sample-okhttp3/src/sample/netcipher/okhttp3/MainActivity.java
@@ -49,6 +49,7 @@ public class MainActivity extends ListActivity implements
     try {
       StrongOkHttpClientBuilder
         .forMaxSecurity(this)
+        .withTorValidation()
         .build(this);
     }
     catch (Exception e) {
@@ -101,6 +102,14 @@ public class MainActivity extends ListActivity implements
   public void onTimeout() {
     Toast
       .makeText(this, R.string.msg_timeout, Toast.LENGTH_LONG)
+      .show();
+    finish();
+  }
+
+  @Override
+  public void onInvalid() {
+    Toast
+      .makeText(this, R.string.msg_invalid, Toast.LENGTH_LONG)
       .show();
     finish();
   }

--- a/sample-volley/res/values/strings.xml
+++ b/sample-volley/res/values/strings.xml
@@ -3,5 +3,6 @@
     <string name="app_name">NetCipher Volley Sample</string>
     <string name="msg_timeout">Tor not available; timed out</string>
     <string name="msg_crash">Ick! We crashed!</string>
+    <string name="msg_invalid">Hey! Our communications are not going over Tor!</string>
 
 </resources>

--- a/sample-volley/src/sample/netcipher/volley/MainActivity.java
+++ b/sample-volley/src/sample/netcipher/volley/MainActivity.java
@@ -50,6 +50,7 @@ public class MainActivity extends ListActivity implements
     try {
       StrongVolleyQueueBuilder
         .forMaxSecurity(this)
+        .withTorValidation()
         .build(this);
     }
     catch (Exception e) {
@@ -111,6 +112,14 @@ public class MainActivity extends ListActivity implements
   public void onTimeout() {
     Toast
       .makeText(this, R.string.msg_timeout, Toast.LENGTH_LONG)
+      .show();
+    finish();
+  }
+
+  @Override
+  public void onInvalid() {
+    Toast
+      .makeText(this, R.string.msg_invalid, Toast.LENGTH_LONG)
       .show();
     finish();
   }


### PR DESCRIPTION
This change adds `validateTor()` to all of the HTTP builders. If called, it will trigger a call to a known Tor URL to help confirm that we are communicating over Tor when we build the resulting HTTP connection object (e.g., `HttpURLConnection`). If the Tor URL returns the expected response, we hand the HTTP connection object to the app via the callback. If there is a problem with the expected response, we call `onInvalid()` on the callback, to indicate that we could not validate the Tor status.

This is opt-in (i.e., you have to call `validateTor()`), as it adds a bit of overhead, bandwidth consumption, and noise on the Tor network.
