### PR TITLE
Fix TLSv1.3 compatibility by not adding TLS_FALLBACK_SCSV

### DIFF
--- a/libnetcipher/src/info/guardianproject/netcipher/client/TlsOnlySocketFactory.java
+++ b/libnetcipher/src/info/guardianproject/netcipher/client/TlsOnlySocketFactory.java
@@ -158,7 +158,7 @@ public class TlsOnlySocketFactory extends SSLSocketFactory {
                  * never even have been an option in TLS.
                  */
                 ArrayList<String> enabled = new ArrayList<String>(10);
-                Pattern exclude = Pattern.compile(".*(EXPORT|NULL).*");
+                Pattern exclude = Pattern.compile(".*(EXPORT|NULL|TLS_FALLBACK_SCSV).*");
                 for (String cipher : delegate.getEnabledCipherSuites()) {
                     if (!exclude.matcher(cipher).matches()) {
                         enabled.add(cipher);
@@ -181,7 +181,7 @@ public class TlsOnlySocketFactory extends SSLSocketFactory {
              * should never even have been an option in TLS.
              */
             ArrayList<String> enabledCiphers = new ArrayList<String>(10);
-            Pattern exclude = Pattern.compile(".*(_DES|DH_|DSS|EXPORT|MD5|NULL|RC4).*");
+            Pattern exclude = Pattern.compile(".*(_DES|DH_|DSS|EXPORT|MD5|NULL|RC4|TLS_FALLBACK_SCSV).*");
             for (String cipher : delegate.getSupportedCipherSuites()) {
                 if (!exclude.matcher(cipher).matches()) {
                     enabledCiphers.add(cipher);


### PR DESCRIPTION
`TLS_FALLBACK_SCSV` **MUST NOT** be set on first connect, see
https://github.com/yeriomin/YalpStore/issues/447#issuecomment-390105926
and RFC 7507 (https://tools.ietf.org/html/rfc7507)

Without this patch **every** android device not supporting TLSv1.3 trying to connect to an TLSv1.3 enabled server will fail!

Some more insights: https://www.mail-archive.com/openssl-users@openssl.org/msg75283.html