### PR TITLE
HttpURLConnection: disable TLS Session Tickets

### DIFF
--- a/libnetcipher/src/info/guardianproject/netcipher/client/TlsOnlySocketFactory.java
+++ b/libnetcipher/src/info/guardianproject/netcipher/client/TlsOnlySocketFactory.java
@@ -89,6 +89,9 @@ public class TlsOnlySocketFactory extends SSLSocketFactory {
         return delegate.getSupportedCipherSuites();
     }
 
+    /**
+     * @see <a href="https://timtaubert.de/blog/2014/11/the-sad-state-of-server-side-tls-session-resumption-implementations/">The sad state of server-side TLS Session Resumption implementations</a>
+     */
     private Socket makeSocketSafe(Socket socket, String host) {
         if (socket instanceof SSLSocket) {
             TlsOnlySSLSocket tempSocket =
@@ -96,8 +99,9 @@ public class TlsOnlySocketFactory extends SSLSocketFactory {
 
             if (delegate instanceof SSLCertificateSocketFactory &&
                     Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
-                ((android.net.SSLCertificateSocketFactory) delegate)
-                        .setHostname(socket, host);
+                SSLCertificateSocketFactory factory = (SSLCertificateSocketFactory) delegate;
+                factory.setHostname(socket, host);
+                factory.setUseSessionTickets(socket, false);
             } else {
                 tempSocket.setHostname(host);
             }


### PR DESCRIPTION
TLS Session Tickets are used to resume TLS sessions.  They are sent in plain text before TLS is started up.  They are in effect a cookie that can be viewed from anyone who can see the network traffic.  Even worse, the server can easily set specific cookies in order to track users.  They are used to speed up renegotiation of TLS on reconnect, so disabling this will cause increased latency and bandwidth usage.

Thanks to @dkg for alerting me to this issue.

https://timtaubert.de/blog/2014/11/the-sad-state-of-server-side-tls-session-resumption-implementations/