### PR TITLE
Removed V2 Onion Service APIs from OrbotHelper

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,6 @@
-#Mon Apr 04 20:11:17 CEST 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.8-bin.zip
+distributionSha256Sum=f3e29692a8faa94eb0b02ebf36fa263a642b3ae8694ef806c45c345b8683f1ba
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4.1-bin.zip
-distributionSha256Sum=e7cf7d1853dfc30c1c44f571d3919eeeedef002823b66b6a988d27e919686389

--- a/libnetcipher/src/info/guardianproject/netcipher/proxy/OrbotHelper.java
+++ b/libnetcipher/src/info/guardianproject/netcipher/proxy/OrbotHelper.java
@@ -114,18 +114,11 @@ public class OrbotHelper implements ProxyHelper {
 
     public final static String ACTION_START_TOR = "org.torproject.android.START_TOR";
     /**
-     * Intent Action to request V2 Onion Services
-     * See {{@link #requestHiddenServiceOnPort(Activity, int)}}
-     */
-    @Deprecated
-    public final static String ACTION_REQUEST_HS = "org.torproject.android.REQUEST_HS_PORT";
-    /**
      * Intent Action to request V3 Onion Services
      * See {{@link #requestV3OnionServiceOnPort(Activity, int, int, String)}}
      */
     public final static String ACTION_REQUEST_V3_ONION_SERVICE = "org.torproject.android.REQUEST_V3_ONION_SERVICE";
     public final static int START_TOR_RESULT = 0x9234;
-    public final static int HS_REQUEST_CODE = 9999;
     public final static int V3_ONION_SERVICE_REQUEST_CODE = 3333;
 
 
@@ -160,7 +153,7 @@ public class OrbotHelper implements ProxyHelper {
     }
 
     /**
-     * Test whether a {@link Uri} is a Tor Hidden Service host name, also known
+     * Test whether a {@link Uri} is a Tor Onion Service host name, also known
      * as an ".onion address".
      *
      * @return whether the host name is a Tor .onion address
@@ -194,20 +187,6 @@ public class OrbotHelper implements ProxyHelper {
         } catch (PackageManager.NameNotFoundException e) {
             return false;
         }
-    }
-
-    /**
-     * This method creates a V2 Onion Service which is being phased out by tor soon.
-     * Instead, you should use {{@link #requestV3OnionServiceOnPort(Activity, int, int, String)}}
-     * to create a V3 Onion Service. See https://blog.torproject.org/v2-deprecation-timeline
-     */
-    @Deprecated
-    public static void requestHiddenServiceOnPort(Activity activity, int port) {
-        Intent intent = new Intent(ACTION_REQUEST_HS);
-        intent.setPackage(ORBOT_PACKAGE_NAME);
-        intent.putExtra("hs_port", port);
-
-        activity.startActivityForResult(intent, HS_REQUEST_CODE);
     }
 
     /**


### PR DESCRIPTION
Orbot/tor no longer accept V2 Onion Addresses. A new version of this library should be released with this change, and also with interfaces for establishing/managing V3 Services (as is being discussed right now in https://github.com/guardianproject/orbot/issues/540 )